### PR TITLE
fix: breaking change for the agent

### DIFF
--- a/changelog/costgraph/agent.mdx
+++ b/changelog/costgraph/agent.mdx
@@ -7,7 +7,7 @@ title: CostGraph Agent
 Agent releases are tagged with a major.minor version number.
 
 ## SLA
-- We will provide changelogs for major and minor releases of the operator
+- We will provide changelogs for major and minor releases of the agent
 - Customers will be made aware of any breaking changes in any release cycle
 - We aim to provide releases regularly for customer features and business priorities
 

--- a/changelog/costgraph/agent.mdx
+++ b/changelog/costgraph/agent.mdx
@@ -4,5 +4,18 @@ title: CostGraph Agent
 ---
 
 # Changelogs
-coming soon to a VM near you
+Agent releases are tagged with a major.minor version number.
+
+## SLA
+- We will provide changelogs for major and minor releases of the operator
+- Customers will be made aware of any breaking changes in any release cycle
+- We aim to provide releases regularly for customer features and business priorities
+
+<Update label="2026-01-25" description="v0.1.38">
+    ### Breaking Changes
+    - We have renamed all existing metrics to have the `costgraph_` prefix. Previous metric definitions confused customers whilst limiting our brand. We thank all our customers for their understanding with this change and look forward to it bringing clarity with no impacting changes in the future. All existing customers will need to update their metric definitions to append the `costgraph_` prefix.
+
+    ### Updates
+    - Bugfix on the agent causing accumulated metrics to accrue metric values inaccurately over time, this now resets on every scrape.
+</Update>
 

--- a/docs.json
+++ b/docs.json
@@ -230,10 +230,7 @@
       "view",
       "chatgpt",
       "claude",
-      "perplexity",
-      "mcp",
-      "cursor",
-      "vscode"
+      "perplexity"
     ]
   }
 }


### PR DESCRIPTION
This pull request updates the CostGraph Agent documentation and configuration, focusing on improving changelog transparency and refining supported documentation tools. The most significant changes are the addition of a detailed changelog policy and a breaking change to metric naming conventions, as well as a cleanup of the documentation configuration.

Changelog and Documentation Updates:

* Added a changelog section to `changelog/costgraph/agent.mdx`, outlining the agent's release versioning, SLA for changelogs, and communication of breaking changes.
* Documented a breaking change: all existing metrics are now prefixed with `costgraph_`, requiring customers to update their metric definitions.
* Added a bugfix note: metric accumulation now resets on every scrape to prevent inaccurate values over time.

Documentation Configuration Cleanup:

* Updated `docs.json` to remove unused documentation tools (`mcp`, `cursor`, `vscode`) from the supported list, keeping only relevant options.