### PR TITLE
docs: add MCP integration

### DIFF
--- a/costgraph/mcp/install.mdx
+++ b/costgraph/mcp/install.mdx
@@ -9,6 +9,10 @@ You already debug your infrastructure inside a coding agent. CostGraph's MCP put
 
 - An API key from [your account settings](https://app.costgraph.ai/settings/account/api-keys).
 
+<Warning>
+  MCP access requires an active billing plan. Set up billing in the [CostGraph dashboard](https://app.costgraph.ai/billing) before connecting.
+</Warning>
+
 Point your agent at the endpoint below, using that key.
 
 ```text


### PR DESCRIPTION
## Summary

- Adds MCP install and usage pages for the CostGraph MCP server
- Covers Codex, Claude Code, Amp, OpenCode, and generic agent config
- Adds billing prerequisite warning on the install page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated installation documentation to include a billing requirement notice, informing users that MCP access requires an active billing plan and directing them to set up billing in the dashboard before connecting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->