### PR TITLE
Add Usage and Billing page with $500 resource-spend freemium

### DIFF
--- a/costgraph/billing.mdx
+++ b/costgraph/billing.mdx
@@ -15,7 +15,7 @@ For detailed pricing and to choose a plan, visit our [pricing page](https://cost
 | **Pricing API** | $0.001 per request |
 | **Enterprise** | Custom pricing: volume discounts, SSO/SAML, dedicated support, SLA, and on-premise deployment |
 
-Resource spend is the monthly cost of the resources CostGraph monitors (nodes and VMs today). MCP and Pricing API requests are billed per request regardless of the freemium threshold.
+Resource spend is the monthly cost of the resources CostGraph bills for (nodes and VMs today, more later). AI assistant (GraphAI + MCP) and Pricing API requests are billed per request regardless of the freemium threshold.
 
 ## Managing billing
 

--- a/costgraph/billing.mdx
+++ b/costgraph/billing.mdx
@@ -1,0 +1,22 @@
+---
+title: 'Usage and Billing'
+---
+
+CostGraph pricing is usage-based. Compute monitoring is free under our freemium model while your monthly resource spend stays under $500; the AI assistant and Pricing API are billed per request.
+
+For detailed pricing and to choose a plan, visit our [pricing page](https://costgraph.baselinehq.cloud/pricing).
+
+## Pricing overview
+
+| Product | Pricing |
+|---------|---------|
+| **Compute** (Kubernetes nodes and VMs) | Free while monthly resource spend is under $500. Above $500, $15 per node or 2% of resource spend, whichever is higher. Includes a 14-day free trial. |
+| **AI assistant** (GraphAI and the CostGraph MCP server) | $0.01 per request |
+| **Pricing API** | $0.001 per request |
+| **Enterprise** | Custom pricing: volume discounts, SSO/SAML, dedicated support, SLA, and on-premise deployment |
+
+Resource spend is the monthly cost of the resources CostGraph monitors (nodes and VMs today). MCP and Pricing API requests are billed per request regardless of the freemium threshold.
+
+## Managing billing
+
+Billing is set up and managed in the CostGraph dashboard, with subscriptions handled securely through Stripe. To manage your plan and payment method, visit your [billing settings](https://costgraph.baselinehq.cloud/dashboard/billing).

--- a/docs.json
+++ b/docs.json
@@ -31,7 +31,8 @@
             "group": "Get Started",
             "pages": [
               "index",
-              "concepts/how-it-works"
+              "concepts/how-it-works",
+              "costgraph/billing"
             ]
           },
           {


### PR DESCRIPTION
Documents current CostGraph pricing in a new **Usage and Billing** page (wired into Get Started nav):

- **Compute** (nodes + VMs): free while monthly resource spend is under $500; above $500, $15 per node or 2% of resource spend, whichever is higher. 14-day trial.
- **AI assistant** (GraphAI + MCP): $0.01/request.
- **Pricing API**: $0.001/request.

'Resource spend' is the monthly cost of the resources CostGraph bills for (nodes and VMs today, more later), so the wording stays correct as the basis grows. Pairs with backend BILLING_COMPUTE_FREEMIUM_CENTS (default $500).