### PR TITLE
Remove the 14-day free-trial note from compute pricing

### DIFF
--- a/costgraph/billing.mdx
+++ b/costgraph/billing.mdx
@@ -10,7 +10,7 @@ For detailed pricing and to choose a plan, visit our [pricing page](https://cost
 
 | Product | Pricing |
 |---------|---------|
-| **Compute** (Kubernetes nodes and VMs) | Free while monthly resource spend is under $500. Above $500, $15 per node or 2% of resource spend, whichever is higher. Includes a 14-day free trial. |
+| **Compute** (Kubernetes nodes and VMs) | Free while monthly resource spend is under $500. Above $500, $15 per node or 2% of resource spend, whichever is higher. |
 | **AI assistant** (GraphAI and the CostGraph MCP server) | $0.01 per request |
 | **Pricing API** | $0.001 per request |
 | **Enterprise** | Custom pricing: volume discounts, SSO/SAML, dedicated support, SLA, and on-premise deployment |


### PR DESCRIPTION
Compute no longer has a 14-day trial; the free tier is "free while monthly resource spend is under $500". Drops the trailing "Includes a 14-day free trial." from the Compute row so the docs match the billing model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the pricing overview to remove the mention of a 14-day free trial for Compute.
  * Clarified that Compute pricing includes a freemium threshold followed by per-node and percentage-based charges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->