### PR TITLE
Add GCP + AWS FOCUS billing integration onboarding guides

### DIFF
--- a/costgraph/integrations/anthropic.mdx
+++ b/costgraph/integrations/anthropic.mdx
@@ -3,79 +3,54 @@ title: Anthropic
 description: "Bring Anthropic cost into CostGraph, pulled by us or pushed by you"
 ---
 
-Anthropic bills API usage per model and token bucket. CostGraph reads the organization usage and cost reports so model spend sits beside your infrastructure cost.
+Anthropic bills API usage per model and token bucket, so model spend lands beside your infrastructure cost.
 
 CostGraph reads Anthropic as **FOCUS 1.2** records at a grain of day x model x token bucket (cost + tokens).
+
+<Card title="Anthropic reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/anthropic.md">
+  The credentials and permissions Anthropic needs, every environment variable, the API
+  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
+  never drifts from the code.
+</Card>
 
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
   <Card title="CostGraph pulls it" icon="cloud-arrow-down">
-    You give us read-only credentials and we call Anthropic once a day. Fastest to set
-    up, and nothing to run.
+    You supply read-only credentials and we call Anthropic once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
-    infrastructure and send us the records. Credentials never leave your side.
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
+    Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
-## Permissions
+## Let CostGraph pull
 
-Create an **Admin key** as an organization admin (Console -> Settings -> Admin keys). Admin keys are distinct from regular API keys and grant read access to organization-wide usage and cost.
-
-<Warning>
-A regular API key will not authenticate against the usage and cost endpoints.
-</Warning>
-
-CostGraph only ever reads. The exact endpoints called are listed in the
-[Anthropic exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/anthropic.md).
-
-## Values you will need
-
-| Variable | Required | Kind |
-|----------|----------|------|
-| `ANTHROPIC_ADMIN_KEY` | Yes | Credential |
-| `ANTHROPIC_ORG_ID` | No | Identifier |
-| `ANTHROPIC_TENANT_GROUP` | No | Identifier |
-
-## Option 1: let CostGraph pull
-
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
-2. Choose **Anthropic** and name the connection.
-3. Enter the billing account these charges belong to, then fill in:
-   - `ANTHROPIC_ADMIN_KEY`
-   - `ANTHROPIC_ORG_ID`
-   - `ANTHROPIC_TENANT_GROUP`
+1. Open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **Anthropic**, name the connection, and enter the billing account these
+   charges belong to.
+3. Fill in the values the form asks for. It lists exactly the variables Anthropic
+   needs, marks which are optional, and links this provider's reference for the
+   permissions each one requires.
 4. Select **Connect**.
 
-CostGraph runs a short verification fetch before saving, so a wrong value or a
-missing permission fails immediately rather than silently at the next sync.
+CostGraph verifies the credentials with a short fetch before saving, so a wrong
+value or a missing permission fails while you are still on the form.
 
 <Note>
 Credentials are encrypted at rest and used only to read billing data. Revoke them in
 Anthropic at any time and the connection stops; nothing else is affected.
 </Note>
 
-## Option 2: push it yourself
+## Push it yourself
 
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with your own credentials:
-
-```bash
-export ANTHROPIC_ADMIN_KEY=...
-export ANTHROPIC_ORG_ID=...
-export ANTHROPIC_TENANT_GROUP=...
-
-focus-exporter --provider anthropic --month 2026-07 --format json
-```
-
-5. Send the output to CostGraph, quoting the connection id and API key.
-
-Every environment variable and the full FOCUS field mapping are documented in the
-[Anthropic exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/anthropic.md).
+4. Run the exporter with `--provider anthropic`, following the
+   [Anthropic reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/anthropic.md) for the environment it needs.
+5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/anthropic.mdx
+++ b/costgraph/integrations/anthropic.mdx
@@ -1,0 +1,84 @@
+---
+title: Anthropic
+description: "Bring Anthropic cost into CostGraph, pulled by us or pushed by you"
+---
+
+Anthropic bills API usage per model and token bucket. CostGraph reads the organization usage and cost reports so model spend sits beside your infrastructure cost.
+
+CostGraph reads Anthropic as **FOCUS 1.2** records at a grain of day x model x token bucket (cost + tokens).
+
+## Choose how the data reaches us
+
+<CardGroup cols={2}>
+  <Card title="CostGraph pulls it" icon="cloud-arrow-down">
+    You give us read-only credentials and we call Anthropic once a day. Fastest to set
+    up, and nothing to run.
+  </Card>
+  <Card title="You push it" icon="cloud-arrow-up">
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
+    infrastructure and send us the records. Credentials never leave your side.
+  </Card>
+</CardGroup>
+
+## Permissions
+
+Create an **Admin key** as an organization admin (Console -> Settings -> Admin keys). Admin keys are distinct from regular API keys and grant read access to organization-wide usage and cost.
+
+<Warning>
+A regular API key will not authenticate against the usage and cost endpoints.
+</Warning>
+
+CostGraph only ever reads. The exact endpoints called are listed in the
+[Anthropic exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/anthropic.md).
+
+## Values you will need
+
+| Variable | Required | Kind |
+|----------|----------|------|
+| `ANTHROPIC_ADMIN_KEY` | Yes | Credential |
+| `ANTHROPIC_ORG_ID` | No | Identifier |
+| `ANTHROPIC_TENANT_GROUP` | No | Identifier |
+
+## Option 1: let CostGraph pull
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **Anthropic** and name the connection.
+3. Enter the billing account these charges belong to, then fill in:
+   - `ANTHROPIC_ADMIN_KEY`
+   - `ANTHROPIC_ORG_ID`
+   - `ANTHROPIC_TENANT_GROUP`
+4. Select **Connect**.
+
+CostGraph runs a short verification fetch before saving, so a wrong value or a
+missing permission fails immediately rather than silently at the next sync.
+
+<Note>
+Credentials are encrypted at rest and used only to read billing data. Revoke them in
+Anthropic at any time and the connection stops; nothing else is affected.
+</Note>
+
+## Option 2: push it yourself
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+2. Create the connection and copy its **Connection ID**.
+3. Create a CostGraph API key with the `focus:write` scope.
+4. Run the exporter with your own credentials:
+
+```bash
+export ANTHROPIC_ADMIN_KEY=...
+export ANTHROPIC_ORG_ID=...
+export ANTHROPIC_TENANT_GROUP=...
+
+focus-exporter --provider anthropic --month 2026-07 --format json
+```
+
+5. Send the output to CostGraph, quoting the connection id and API key.
+
+Every environment variable and the full FOCUS field mapping are documented in the
+[Anthropic exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/anthropic.md).
+
+## What CostGraph does with it
+
+Records land as raw billing rows, are normalised into line items, and roll up into
+daily cost. From there Anthropic spend appears in Cost Overview and in anomaly
+detection alongside every other provider.

--- a/costgraph/integrations/aws.mdx
+++ b/costgraph/integrations/aws.mdx
@@ -1,0 +1,92 @@
+---
+title: Amazon Web Services
+description: "Connect an AWS account to CostGraph for FOCUS-based cost, allocation, and cross-provider recommendations"
+---
+
+CostGraph reads your AWS spend from a **FOCUS Data Export** delivered to S3. Unlike
+Google Cloud, AWS exposes a full API for this, so the entire setup can be automated -
+CostGraph (or a short Terraform module) creates the export and the read role for you.
+
+## What you enable
+
+A single **FOCUS 1.2 Data Export** (`FOCUS_1_2_AWS`) written as Parquet to an S3
+bucket. It carries billed and effective cost, usage, credits, and commitment
+(Savings Plans / Reserved Instances) columns in the normalized FOCUS schema.
+
+## Automated setup (recommended)
+
+CostGraph creates the export on your behalf when you connect with a role that allows
+`bcm-data-exports` and S3 bucket management, or you can apply the Terraform below. The
+export is created in **us-east-1** (where AWS billing data lives).
+
+```hcl
+resource "aws_s3_bucket" "focus" {
+  bucket = "costgraph-focus-export-${data.aws_caller_identity.current.account_id}"
+}
+
+resource "aws_s3_bucket_policy" "focus" {
+  bucket = aws_s3_bucket.focus.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid       = "EnableAWSDataExportsWrite"
+      Effect    = "Allow"
+      Principal = { Service = ["billingreports.amazonaws.com", "bcm-data-exports.amazonaws.com"] }
+      Action    = ["s3:PutObject", "s3:GetBucketPolicy"]
+      Resource  = [aws_s3_bucket.focus.arn, "${aws_s3_bucket.focus.arn}/*"]
+      Condition = {
+        StringLike   = { "aws:SourceArn" = [
+          "arn:aws:cur:us-east-1:${data.aws_caller_identity.current.account_id}:definition/*",
+          "arn:aws:bcm-data-exports:us-east-1:${data.aws_caller_identity.current.account_id}:export/*"
+        ] }
+        StringEquals = { "aws:SourceAccount" = data.aws_caller_identity.current.account_id }
+      }
+    }]
+  })
+}
+
+resource "aws_bcmdataexports_export" "focus" {
+  export {
+    name = "costgraph-focus-1-2"
+    data_query { query_statement = "SELECT * FROM FOCUS_1_2_AWS" }
+    destination_configurations {
+      s3_destination {
+        s3_bucket = aws_s3_bucket.focus.id
+        s3_prefix = "focus-1-2"
+        s3_region = "us-east-1"
+        s3_output_configurations {
+          output_type = "CUSTOM"
+          format      = "PARQUET"
+          compression = "PARQUET"
+          overwrite   = "OVERWRITE_REPORT"
+        }
+      }
+    }
+    refresh_cadence { frequency = "SYNCHRONOUS" }
+  }
+}
+```
+
+First Parquet files land within about 24 hours.
+
+## Read access
+
+CostGraph reads the export bucket with a cross-account role granting `s3:GetObject` and
+`s3:ListBucket` on the export prefix. The connect flow provides the exact trust policy
+and external ID.
+
+## Connect in CostGraph
+
+1. Open **Integrations** and choose **Amazon Web Services**.
+2. Provide the read role (and, for automated setup, the provisioning role), then connect.
+3. CostGraph creates or discovers the FOCUS export, validates access, and starts the
+   first sync.
+
+## What CostGraph does with it
+
+- **Cost**: FOCUS line items normalized to the same canonical model as every other
+  provider, keeping billed and effective cost, credits, and commitment attribution.
+- **Reconciliation**: allocated plus unallocated cost is checked to equal the invoice
+  per billing account per month.
+- **Allocation**: spend attributed by resource, tag, and account, with an explicit
+  unallocated bucket for tax, shared, and commitment costs.

--- a/costgraph/integrations/confluent.mdx
+++ b/costgraph/integrations/confluent.mdx
@@ -1,0 +1,84 @@
+---
+title: Confluent Cloud
+description: "Bring Confluent Cloud cost into CostGraph, pulled by us or pushed by you"
+---
+
+Confluent Cloud bills per product and resource. CostGraph reads the billing API so Kafka spend is attributed per cluster and environment.
+
+CostGraph reads Confluent Cloud as **FOCUS 1.2** records at a grain of billing line item (product x resource).
+
+## Choose how the data reaches us
+
+<CardGroup cols={2}>
+  <Card title="CostGraph pulls it" icon="cloud-arrow-down">
+    You give us read-only credentials and we call Confluent Cloud once a day. Fastest to set
+    up, and nothing to run.
+  </Card>
+  <Card title="You push it" icon="cloud-arrow-up">
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
+    infrastructure and send us the records. Credentials never leave your side.
+  </Card>
+</CardGroup>
+
+## Permissions
+
+Create a **Cloud API key** (org-scoped, not a cluster or resource key) whose owner holds the **OrganizationAdmin** or **BillingAdmin** role.
+
+<Warning>
+A resource-scoped key, or a key without a billing role, returns `403`.
+</Warning>
+
+CostGraph only ever reads. The exact endpoints called are listed in the
+[Confluent Cloud exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/confluent.md).
+
+## Values you will need
+
+| Variable | Required | Kind |
+|----------|----------|------|
+| `CONFLUENT_CLOUD_API_KEY` | Yes | Credential |
+| `CONFLUENT_CLOUD_API_SECRET` | Yes | Credential |
+| `CONFLUENT_ORG_ID` | Yes | Identifier |
+
+## Option 1: let CostGraph pull
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **Confluent Cloud** and name the connection.
+3. Enter the billing account these charges belong to, then fill in:
+   - `CONFLUENT_CLOUD_API_KEY`
+   - `CONFLUENT_CLOUD_API_SECRET`
+   - `CONFLUENT_ORG_ID`
+4. Select **Connect**.
+
+CostGraph runs a short verification fetch before saving, so a wrong value or a
+missing permission fails immediately rather than silently at the next sync.
+
+<Note>
+Credentials are encrypted at rest and used only to read billing data. Revoke them in
+Confluent Cloud at any time and the connection stops; nothing else is affected.
+</Note>
+
+## Option 2: push it yourself
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+2. Create the connection and copy its **Connection ID**.
+3. Create a CostGraph API key with the `focus:write` scope.
+4. Run the exporter with your own credentials:
+
+```bash
+export CONFLUENT_CLOUD_API_KEY=...
+export CONFLUENT_CLOUD_API_SECRET=...
+export CONFLUENT_ORG_ID=...
+
+focus-exporter --provider confluent --month 2026-07 --format json
+```
+
+5. Send the output to CostGraph, quoting the connection id and API key.
+
+Every environment variable and the full FOCUS field mapping are documented in the
+[Confluent Cloud exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/confluent.md).
+
+## What CostGraph does with it
+
+Records land as raw billing rows, are normalised into line items, and roll up into
+daily cost. From there Confluent Cloud spend appears in Cost Overview and in anomaly
+detection alongside every other provider.

--- a/costgraph/integrations/confluent.mdx
+++ b/costgraph/integrations/confluent.mdx
@@ -3,79 +3,54 @@ title: Confluent Cloud
 description: "Bring Confluent Cloud cost into CostGraph, pulled by us or pushed by you"
 ---
 
-Confluent Cloud bills per product and resource. CostGraph reads the billing API so Kafka spend is attributed per cluster and environment.
+Confluent Cloud bills per product and resource, so Kafka spend is attributed per cluster and environment.
 
 CostGraph reads Confluent Cloud as **FOCUS 1.2** records at a grain of billing line item (product x resource).
+
+<Card title="Confluent Cloud reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/confluent.md">
+  The credentials and permissions Confluent Cloud needs, every environment variable, the API
+  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
+  never drifts from the code.
+</Card>
 
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
   <Card title="CostGraph pulls it" icon="cloud-arrow-down">
-    You give us read-only credentials and we call Confluent Cloud once a day. Fastest to set
-    up, and nothing to run.
+    You supply read-only credentials and we call Confluent Cloud once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
-    infrastructure and send us the records. Credentials never leave your side.
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
+    Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
-## Permissions
+## Let CostGraph pull
 
-Create a **Cloud API key** (org-scoped, not a cluster or resource key) whose owner holds the **OrganizationAdmin** or **BillingAdmin** role.
-
-<Warning>
-A resource-scoped key, or a key without a billing role, returns `403`.
-</Warning>
-
-CostGraph only ever reads. The exact endpoints called are listed in the
-[Confluent Cloud exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/confluent.md).
-
-## Values you will need
-
-| Variable | Required | Kind |
-|----------|----------|------|
-| `CONFLUENT_CLOUD_API_KEY` | Yes | Credential |
-| `CONFLUENT_CLOUD_API_SECRET` | Yes | Credential |
-| `CONFLUENT_ORG_ID` | Yes | Identifier |
-
-## Option 1: let CostGraph pull
-
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
-2. Choose **Confluent Cloud** and name the connection.
-3. Enter the billing account these charges belong to, then fill in:
-   - `CONFLUENT_CLOUD_API_KEY`
-   - `CONFLUENT_CLOUD_API_SECRET`
-   - `CONFLUENT_ORG_ID`
+1. Open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **Confluent Cloud**, name the connection, and enter the billing account these
+   charges belong to.
+3. Fill in the values the form asks for. It lists exactly the variables Confluent Cloud
+   needs, marks which are optional, and links this provider's reference for the
+   permissions each one requires.
 4. Select **Connect**.
 
-CostGraph runs a short verification fetch before saving, so a wrong value or a
-missing permission fails immediately rather than silently at the next sync.
+CostGraph verifies the credentials with a short fetch before saving, so a wrong
+value or a missing permission fails while you are still on the form.
 
 <Note>
 Credentials are encrypted at rest and used only to read billing data. Revoke them in
 Confluent Cloud at any time and the connection stops; nothing else is affected.
 </Note>
 
-## Option 2: push it yourself
+## Push it yourself
 
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with your own credentials:
-
-```bash
-export CONFLUENT_CLOUD_API_KEY=...
-export CONFLUENT_CLOUD_API_SECRET=...
-export CONFLUENT_ORG_ID=...
-
-focus-exporter --provider confluent --month 2026-07 --format json
-```
-
-5. Send the output to CostGraph, quoting the connection id and API key.
-
-Every environment variable and the full FOCUS field mapping are documented in the
-[Confluent Cloud exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/confluent.md).
+4. Run the exporter with `--provider confluent`, following the
+   [Confluent Cloud reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/confluent.md) for the environment it needs.
+5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/gcp.mdx
+++ b/costgraph/integrations/gcp.mdx
@@ -1,0 +1,93 @@
+---
+title: Google Cloud
+description: "Connect a Google Cloud billing account to CostGraph for FOCUS-based cost, allocation, and cross-provider recommendations"
+---
+
+CostGraph reads your Google Cloud spend from a **FOCUS billing export** in BigQuery. You
+enable the export on your billing account, grant a read-only service account access to
+the exported data, and CostGraph ingests it into normalized, reconciled cost.
+
+Google does not offer an API to turn the billing export on, so one step is a manual
+click in the Cloud Console. Everything else is read-only and least-privilege.
+
+## What you enable
+
+| Export | Required | Why |
+|--------|----------|-----|
+| **FOCUS** | Yes | The normalized, cross-provider cost feed CostGraph ingests |
+| **Detailed usage cost** | Yes | Reconciles the (Preview) FOCUS export and adds resource-level rows |
+| Standard usage cost | No | Detailed is a superset; skip it |
+| Pricing | No | Used later for catalog pricing, not cost ingestion |
+
+## Step 1: Enable the exports (Console)
+
+<Note>
+Enabling a billing export is **Console-only** - Google provides no API, gcloud command,
+or Terraform resource for the toggle itself. This is the one manual step.
+</Note>
+
+1. In the Cloud Console, open **Billing** and select the billing account you want to
+   connect.
+2. Go to **Billing export -> BigQuery export**.
+3. Under **FOCUS export**, click **Edit settings**, choose a **region** (US or EU), and
+   **Save**. Google creates its own immutable dataset named
+   `gcp_billing_immutable_<BILLING_ACCOUNT_ID>_<region>` - you do not pick the dataset.
+4. Under **Detailed usage cost**, click **Edit settings**, choose a project and dataset
+   (or let it create `gcp_billing_export_resource_v1_<region>`), and **Save**.
+
+First rows appear within a few hours. A multi-region export backfills roughly the
+previous month.
+
+## Step 2: Grant CostGraph read access
+
+Create a service account for the billing reads (or reuse one), and note the project
+that holds the export datasets. Grant it, least-privilege:
+
+| Role | Scope | Why |
+|------|-------|-----|
+| `roles/bigquery.jobUser` | export project | Run the read queries |
+| `roles/bigquery.dataViewer` | the FOCUS dataset | Read FOCUS cost rows |
+| `roles/bigquery.dataViewer` | the Detailed dataset | Read Detailed rows for reconciliation |
+
+Dataset-level `dataViewer` (rather than project-level) keeps access scoped to the
+billing data only.
+
+<Note>
+**Keyless is recommended.** Rather than exporting a service-account key, grant
+CostGraph's identity permission to impersonate this service account (via Workload
+Identity Federation or `roles/iam.serviceAccountTokenCreator`). No secret leaves your
+project and there is no key to rotate. The connect screen provides CostGraph's
+identity to authorize. A downloaded service-account key is supported as a fallback.
+</Note>
+
+CostGraph does not use OAuth "sign in with Google" for billing access - that ties
+access to one person's account and grants broad scopes. Impersonation (or a scoped
+service-account key) is the correct trust model.
+
+## Step 3: Connect in CostGraph
+
+1. Open **Integrations** and choose **Google Cloud**.
+2. Choose **impersonation** (recommended - authorize CostGraph's identity on your
+   service account) or paste a **service-account key**, then enter the **billing
+   account ID**.
+3. CostGraph validates it can run a query and read the FOCUS dataset, then starts the
+   first sync. If a role is missing, the connect screen names the exact grant to add.
+
+## What CostGraph does with it
+
+- **Cost**: FOCUS line items normalized to a canonical model, keeping both billed and
+  effective (amortized) cost, credits, and commitment attribution.
+- **Reconciliation**: allocated plus unallocated cost is checked to equal the invoice
+  per billing account per month; FOCUS is validated against the Detailed export.
+- **Allocation**: spend attributed by resource, label, and project, with an explicit
+  unallocated bucket for tax, shared, and commitment costs.
+
+## Automating the setup
+
+Everything except the export toggle can be provisioned as code:
+
+- `google_bigquery_dataset` for the Detailed destination
+- `google_bigquery_dataset_iam_member` / `google_project_iam_member` for the grants
+- `google_project_service` to enable the BigQuery API
+
+The FOCUS export toggle remains a one-time manual Console step per billing account.

--- a/costgraph/integrations/helicone.mdx
+++ b/costgraph/integrations/helicone.mdx
@@ -1,0 +1,80 @@
+---
+title: Helicone
+description: "Bring Helicone cost into CostGraph, pulled by us or pushed by you"
+---
+
+Helicone is an LLM gateway, so one connection captures spend across every model and upstream provider you route through it.
+
+CostGraph reads Helicone as **FOCUS 1.2** records at a grain of day x model x upstream provider (request spend).
+
+## Choose how the data reaches us
+
+<CardGroup cols={2}>
+  <Card title="CostGraph pulls it" icon="cloud-arrow-down">
+    You give us read-only credentials and we call Helicone once a day. Fastest to set
+    up, and nothing to run.
+  </Card>
+  <Card title="You push it" icon="cloud-arrow-up">
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
+    infrastructure and send us the records. Credentials never leave your side.
+  </Card>
+</CardGroup>
+
+## Permissions
+
+Create an API key (`sk-helicone-...`) in Helicone. It is sent as a bearer token and only reads request logs.
+
+CostGraph only ever reads. The exact endpoints called are listed in the
+[Helicone exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/helicone.md).
+
+## Values you will need
+
+| Variable | Required | Kind |
+|----------|----------|------|
+| `HELICONE_API_KEY` | Yes | Credential |
+| `HELICONE_ORG_ID` | Yes | Identifier |
+| `HELICONE_TENANT_PROPERTY` | No | Identifier |
+
+## Option 1: let CostGraph pull
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **Helicone** and name the connection.
+3. Enter the billing account these charges belong to, then fill in:
+   - `HELICONE_API_KEY`
+   - `HELICONE_ORG_ID`
+   - `HELICONE_TENANT_PROPERTY`
+4. Select **Connect**.
+
+CostGraph runs a short verification fetch before saving, so a wrong value or a
+missing permission fails immediately rather than silently at the next sync.
+
+<Note>
+Credentials are encrypted at rest and used only to read billing data. Revoke them in
+Helicone at any time and the connection stops; nothing else is affected.
+</Note>
+
+## Option 2: push it yourself
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+2. Create the connection and copy its **Connection ID**.
+3. Create a CostGraph API key with the `focus:write` scope.
+4. Run the exporter with your own credentials:
+
+```bash
+export HELICONE_API_KEY=...
+export HELICONE_ORG_ID=...
+export HELICONE_TENANT_PROPERTY=...
+
+focus-exporter --provider helicone --month 2026-07 --format json
+```
+
+5. Send the output to CostGraph, quoting the connection id and API key.
+
+Every environment variable and the full FOCUS field mapping are documented in the
+[Helicone exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/helicone.md).
+
+## What CostGraph does with it
+
+Records land as raw billing rows, are normalised into line items, and roll up into
+daily cost. From there Helicone spend appears in Cost Overview and in anomaly
+detection alongside every other provider.

--- a/costgraph/integrations/helicone.mdx
+++ b/costgraph/integrations/helicone.mdx
@@ -7,71 +7,50 @@ Helicone is an LLM gateway, so one connection captures spend across every model 
 
 CostGraph reads Helicone as **FOCUS 1.2** records at a grain of day x model x upstream provider (request spend).
 
+<Card title="Helicone reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/helicone.md">
+  The credentials and permissions Helicone needs, every environment variable, the API
+  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
+  never drifts from the code.
+</Card>
+
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
   <Card title="CostGraph pulls it" icon="cloud-arrow-down">
-    You give us read-only credentials and we call Helicone once a day. Fastest to set
-    up, and nothing to run.
+    You supply read-only credentials and we call Helicone once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
-    infrastructure and send us the records. Credentials never leave your side.
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
+    Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
-## Permissions
+## Let CostGraph pull
 
-Create an API key (`sk-helicone-...`) in Helicone. It is sent as a bearer token and only reads request logs.
-
-CostGraph only ever reads. The exact endpoints called are listed in the
-[Helicone exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/helicone.md).
-
-## Values you will need
-
-| Variable | Required | Kind |
-|----------|----------|------|
-| `HELICONE_API_KEY` | Yes | Credential |
-| `HELICONE_ORG_ID` | Yes | Identifier |
-| `HELICONE_TENANT_PROPERTY` | No | Identifier |
-
-## Option 1: let CostGraph pull
-
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
-2. Choose **Helicone** and name the connection.
-3. Enter the billing account these charges belong to, then fill in:
-   - `HELICONE_API_KEY`
-   - `HELICONE_ORG_ID`
-   - `HELICONE_TENANT_PROPERTY`
+1. Open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **Helicone**, name the connection, and enter the billing account these
+   charges belong to.
+3. Fill in the values the form asks for. It lists exactly the variables Helicone
+   needs, marks which are optional, and links this provider's reference for the
+   permissions each one requires.
 4. Select **Connect**.
 
-CostGraph runs a short verification fetch before saving, so a wrong value or a
-missing permission fails immediately rather than silently at the next sync.
+CostGraph verifies the credentials with a short fetch before saving, so a wrong
+value or a missing permission fails while you are still on the form.
 
 <Note>
 Credentials are encrypted at rest and used only to read billing data. Revoke them in
 Helicone at any time and the connection stops; nothing else is affected.
 </Note>
 
-## Option 2: push it yourself
+## Push it yourself
 
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with your own credentials:
-
-```bash
-export HELICONE_API_KEY=...
-export HELICONE_ORG_ID=...
-export HELICONE_TENANT_PROPERTY=...
-
-focus-exporter --provider helicone --month 2026-07 --format json
-```
-
-5. Send the output to CostGraph, quoting the connection id and API key.
-
-Every environment variable and the full FOCUS field mapping are documented in the
-[Helicone exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/helicone.md).
+4. Run the exporter with `--provider helicone`, following the
+   [Helicone reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/helicone.md) for the environment it needs.
+5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/modal.mdx
+++ b/costgraph/integrations/modal.mdx
@@ -3,75 +3,54 @@ title: Modal
 description: "Bring Modal cost into CostGraph, pulled by us or pushed by you"
 ---
 
-Modal bills serverless GPU and compute per object. CostGraph reads the usage API so per-function CPU, memory, and GPU cost is attributed.
+Modal bills serverless GPU and compute per object, so per-function CPU, memory, and GPU cost is attributed.
 
 CostGraph reads Modal as **FOCUS 1.2** records at a grain of day x object (per-resource CPU/mem/GPU cost).
+
+<Card title="Modal reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/modal.md">
+  The credentials and permissions Modal needs, every environment variable, the API
+  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
+  never drifts from the code.
+</Card>
 
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
   <Card title="CostGraph pulls it" icon="cloud-arrow-down">
-    You give us read-only credentials and we call Modal once a day. Fastest to set
-    up, and nothing to run.
+    You supply read-only credentials and we call Modal once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
-    infrastructure and send us the records. Credentials never leave your side.
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
+    Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
-## Permissions
+## Let CostGraph pull
 
-Create a token with `modal token new`. It is sent as gRPC metadata and only reads usage.
-
-CostGraph only ever reads. The exact endpoints called are listed in the
-[Modal exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/modal.md).
-
-## Values you will need
-
-| Variable | Required | Kind |
-|----------|----------|------|
-| `MODAL_TOKEN_ID` | Yes | Credential |
-| `MODAL_TOKEN_SECRET` | Yes | Credential |
-| `MODAL_WORKSPACE_ID` | Yes | Identifier |
-
-## Option 1: let CostGraph pull
-
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
-2. Choose **Modal** and name the connection.
-3. Enter the billing account these charges belong to, then fill in:
-   - `MODAL_TOKEN_ID`
-   - `MODAL_TOKEN_SECRET`
-   - `MODAL_WORKSPACE_ID`
+1. Open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **Modal**, name the connection, and enter the billing account these
+   charges belong to.
+3. Fill in the values the form asks for. It lists exactly the variables Modal
+   needs, marks which are optional, and links this provider's reference for the
+   permissions each one requires.
 4. Select **Connect**.
 
-CostGraph runs a short verification fetch before saving, so a wrong value or a
-missing permission fails immediately rather than silently at the next sync.
+CostGraph verifies the credentials with a short fetch before saving, so a wrong
+value or a missing permission fails while you are still on the form.
 
 <Note>
 Credentials are encrypted at rest and used only to read billing data. Revoke them in
 Modal at any time and the connection stops; nothing else is affected.
 </Note>
 
-## Option 2: push it yourself
+## Push it yourself
 
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with your own credentials:
-
-```bash
-export MODAL_TOKEN_ID=...
-export MODAL_TOKEN_SECRET=...
-export MODAL_WORKSPACE_ID=...
-
-focus-exporter --provider modal --month 2026-07 --format json
-```
-
-5. Send the output to CostGraph, quoting the connection id and API key.
-
-Every environment variable and the full FOCUS field mapping are documented in the
-[Modal exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/modal.md).
+4. Run the exporter with `--provider modal`, following the
+   [Modal reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/modal.md) for the environment it needs.
+5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/modal.mdx
+++ b/costgraph/integrations/modal.mdx
@@ -1,0 +1,80 @@
+---
+title: Modal
+description: "Bring Modal cost into CostGraph, pulled by us or pushed by you"
+---
+
+Modal bills serverless GPU and compute per object. CostGraph reads the usage API so per-function CPU, memory, and GPU cost is attributed.
+
+CostGraph reads Modal as **FOCUS 1.2** records at a grain of day x object (per-resource CPU/mem/GPU cost).
+
+## Choose how the data reaches us
+
+<CardGroup cols={2}>
+  <Card title="CostGraph pulls it" icon="cloud-arrow-down">
+    You give us read-only credentials and we call Modal once a day. Fastest to set
+    up, and nothing to run.
+  </Card>
+  <Card title="You push it" icon="cloud-arrow-up">
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
+    infrastructure and send us the records. Credentials never leave your side.
+  </Card>
+</CardGroup>
+
+## Permissions
+
+Create a token with `modal token new`. It is sent as gRPC metadata and only reads usage.
+
+CostGraph only ever reads. The exact endpoints called are listed in the
+[Modal exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/modal.md).
+
+## Values you will need
+
+| Variable | Required | Kind |
+|----------|----------|------|
+| `MODAL_TOKEN_ID` | Yes | Credential |
+| `MODAL_TOKEN_SECRET` | Yes | Credential |
+| `MODAL_WORKSPACE_ID` | Yes | Identifier |
+
+## Option 1: let CostGraph pull
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **Modal** and name the connection.
+3. Enter the billing account these charges belong to, then fill in:
+   - `MODAL_TOKEN_ID`
+   - `MODAL_TOKEN_SECRET`
+   - `MODAL_WORKSPACE_ID`
+4. Select **Connect**.
+
+CostGraph runs a short verification fetch before saving, so a wrong value or a
+missing permission fails immediately rather than silently at the next sync.
+
+<Note>
+Credentials are encrypted at rest and used only to read billing data. Revoke them in
+Modal at any time and the connection stops; nothing else is affected.
+</Note>
+
+## Option 2: push it yourself
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+2. Create the connection and copy its **Connection ID**.
+3. Create a CostGraph API key with the `focus:write` scope.
+4. Run the exporter with your own credentials:
+
+```bash
+export MODAL_TOKEN_ID=...
+export MODAL_TOKEN_SECRET=...
+export MODAL_WORKSPACE_ID=...
+
+focus-exporter --provider modal --month 2026-07 --format json
+```
+
+5. Send the output to CostGraph, quoting the connection id and API key.
+
+Every environment variable and the full FOCUS field mapping are documented in the
+[Modal exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/modal.md).
+
+## What CostGraph does with it
+
+Records land as raw billing rows, are normalised into line items, and roll up into
+daily cost. From there Modal spend appears in Cost Overview and in anomaly
+detection alongside every other provider.

--- a/costgraph/integrations/openai.mdx
+++ b/costgraph/integrations/openai.mdx
@@ -3,79 +3,54 @@ title: OpenAI
 description: "Bring OpenAI cost into CostGraph, pulled by us or pushed by you"
 ---
 
-OpenAI bills API usage per model and token bucket. CostGraph reads the organization usage and cost endpoints so model spend sits beside your infrastructure cost.
+OpenAI bills API usage per model and token bucket, so model spend lands beside your infrastructure cost.
 
 CostGraph reads OpenAI as **FOCUS 1.2** records at a grain of day x model x token bucket (billed cost + quantity).
+
+<Card title="OpenAI reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openai.md">
+  The credentials and permissions OpenAI needs, every environment variable, the API
+  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
+  never drifts from the code.
+</Card>
 
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
   <Card title="CostGraph pulls it" icon="cloud-arrow-down">
-    You give us read-only credentials and we call OpenAI once a day. Fastest to set
-    up, and nothing to run.
+    You supply read-only credentials and we call OpenAI once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
-    infrastructure and send us the records. Credentials never leave your side.
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
+    Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
-## Permissions
+## Let CostGraph pull
 
-Create an **Admin key** (`sk-admin-...`) as an organization owner (Settings -> Organization -> Admin keys), or grant an existing key the **`api.usage.read`** scope.
-
-<Warning>
-A regular or service-account key without that scope returns `403 Missing scopes`.
-</Warning>
-
-CostGraph only ever reads. The exact endpoints called are listed in the
-[OpenAI exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openai.md).
-
-## Values you will need
-
-| Variable | Required | Kind |
-|----------|----------|------|
-| `OPENAI_ADMIN_KEY` | Yes | Credential |
-| `OPENAI_ORG_ID` | Yes | Identifier |
-| `OPENAI_TENANT_GROUP` | No | Identifier |
-
-## Option 1: let CostGraph pull
-
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
-2. Choose **OpenAI** and name the connection.
-3. Enter the billing account these charges belong to, then fill in:
-   - `OPENAI_ADMIN_KEY`
-   - `OPENAI_ORG_ID`
-   - `OPENAI_TENANT_GROUP`
+1. Open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **OpenAI**, name the connection, and enter the billing account these
+   charges belong to.
+3. Fill in the values the form asks for. It lists exactly the variables OpenAI
+   needs, marks which are optional, and links this provider's reference for the
+   permissions each one requires.
 4. Select **Connect**.
 
-CostGraph runs a short verification fetch before saving, so a wrong value or a
-missing permission fails immediately rather than silently at the next sync.
+CostGraph verifies the credentials with a short fetch before saving, so a wrong
+value or a missing permission fails while you are still on the form.
 
 <Note>
 Credentials are encrypted at rest and used only to read billing data. Revoke them in
 OpenAI at any time and the connection stops; nothing else is affected.
 </Note>
 
-## Option 2: push it yourself
+## Push it yourself
 
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with your own credentials:
-
-```bash
-export OPENAI_ADMIN_KEY=...
-export OPENAI_ORG_ID=...
-export OPENAI_TENANT_GROUP=...
-
-focus-exporter --provider openai --month 2026-07 --format json
-```
-
-5. Send the output to CostGraph, quoting the connection id and API key.
-
-Every environment variable and the full FOCUS field mapping are documented in the
-[OpenAI exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openai.md).
+4. Run the exporter with `--provider openai`, following the
+   [OpenAI reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openai.md) for the environment it needs.
+5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/openai.mdx
+++ b/costgraph/integrations/openai.mdx
@@ -1,0 +1,84 @@
+---
+title: OpenAI
+description: "Bring OpenAI cost into CostGraph, pulled by us or pushed by you"
+---
+
+OpenAI bills API usage per model and token bucket. CostGraph reads the organization usage and cost endpoints so model spend sits beside your infrastructure cost.
+
+CostGraph reads OpenAI as **FOCUS 1.2** records at a grain of day x model x token bucket (billed cost + quantity).
+
+## Choose how the data reaches us
+
+<CardGroup cols={2}>
+  <Card title="CostGraph pulls it" icon="cloud-arrow-down">
+    You give us read-only credentials and we call OpenAI once a day. Fastest to set
+    up, and nothing to run.
+  </Card>
+  <Card title="You push it" icon="cloud-arrow-up">
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
+    infrastructure and send us the records. Credentials never leave your side.
+  </Card>
+</CardGroup>
+
+## Permissions
+
+Create an **Admin key** (`sk-admin-...`) as an organization owner (Settings -> Organization -> Admin keys), or grant an existing key the **`api.usage.read`** scope.
+
+<Warning>
+A regular or service-account key without that scope returns `403 Missing scopes`.
+</Warning>
+
+CostGraph only ever reads. The exact endpoints called are listed in the
+[OpenAI exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openai.md).
+
+## Values you will need
+
+| Variable | Required | Kind |
+|----------|----------|------|
+| `OPENAI_ADMIN_KEY` | Yes | Credential |
+| `OPENAI_ORG_ID` | Yes | Identifier |
+| `OPENAI_TENANT_GROUP` | No | Identifier |
+
+## Option 1: let CostGraph pull
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **OpenAI** and name the connection.
+3. Enter the billing account these charges belong to, then fill in:
+   - `OPENAI_ADMIN_KEY`
+   - `OPENAI_ORG_ID`
+   - `OPENAI_TENANT_GROUP`
+4. Select **Connect**.
+
+CostGraph runs a short verification fetch before saving, so a wrong value or a
+missing permission fails immediately rather than silently at the next sync.
+
+<Note>
+Credentials are encrypted at rest and used only to read billing data. Revoke them in
+OpenAI at any time and the connection stops; nothing else is affected.
+</Note>
+
+## Option 2: push it yourself
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+2. Create the connection and copy its **Connection ID**.
+3. Create a CostGraph API key with the `focus:write` scope.
+4. Run the exporter with your own credentials:
+
+```bash
+export OPENAI_ADMIN_KEY=...
+export OPENAI_ORG_ID=...
+export OPENAI_TENANT_GROUP=...
+
+focus-exporter --provider openai --month 2026-07 --format json
+```
+
+5. Send the output to CostGraph, quoting the connection id and API key.
+
+Every environment variable and the full FOCUS field mapping are documented in the
+[OpenAI exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openai.md).
+
+## What CostGraph does with it
+
+Records land as raw billing rows, are normalised into line items, and roll up into
+daily cost. From there OpenAI spend appears in Cost Overview and in anomaly
+detection alongside every other provider.

--- a/costgraph/integrations/openrouter.mdx
+++ b/costgraph/integrations/openrouter.mdx
@@ -3,76 +3,54 @@ title: OpenRouter
 description: "Bring OpenRouter cost into CostGraph, pulled by us or pushed by you"
 ---
 
-OpenRouter routes requests to many upstream models. One connection captures credit spend across every model and provider you route through it.
+OpenRouter routes requests to many upstream models, so one connection captures credit spend across all of them.
 
 CostGraph reads OpenRouter as **FOCUS 1.2** records at a grain of day x model x upstream provider (credit spend).
+
+<Card title="OpenRouter reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openrouter.md">
+  The credentials and permissions OpenRouter needs, every environment variable, the API
+  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
+  never drifts from the code.
+</Card>
 
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
   <Card title="CostGraph pulls it" icon="cloud-arrow-down">
-    You give us read-only credentials and we call OpenRouter once a day. Fastest to set
-    up, and nothing to run.
+    You supply read-only credentials and we call OpenRouter once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
-    infrastructure and send us the records. Credentials never leave your side.
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
+    Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
-## Permissions
+## Let CostGraph pull
 
-Create a **management key** at openrouter.ai/settings/management-keys.
-
-<Warning>
-A normal `sk-or-v1-` inference key returns `403 - Only management keys can perform this operation`.
-</Warning>
-
-CostGraph only ever reads. The exact endpoints called are listed in the
-[OpenRouter exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openrouter.md).
-
-## Values you will need
-
-| Variable | Required | Kind |
-|----------|----------|------|
-| `OPENROUTER_MANAGEMENT_KEY` | Yes | Credential |
-| `OPENROUTER_ORG_ID` | Yes | Identifier |
-
-## Option 1: let CostGraph pull
-
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
-2. Choose **OpenRouter** and name the connection.
-3. Enter the billing account these charges belong to, then fill in:
-   - `OPENROUTER_MANAGEMENT_KEY`
-   - `OPENROUTER_ORG_ID`
+1. Open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **OpenRouter**, name the connection, and enter the billing account these
+   charges belong to.
+3. Fill in the values the form asks for. It lists exactly the variables OpenRouter
+   needs, marks which are optional, and links this provider's reference for the
+   permissions each one requires.
 4. Select **Connect**.
 
-CostGraph runs a short verification fetch before saving, so a wrong value or a
-missing permission fails immediately rather than silently at the next sync.
+CostGraph verifies the credentials with a short fetch before saving, so a wrong
+value or a missing permission fails while you are still on the form.
 
 <Note>
 Credentials are encrypted at rest and used only to read billing data. Revoke them in
 OpenRouter at any time and the connection stops; nothing else is affected.
 </Note>
 
-## Option 2: push it yourself
+## Push it yourself
 
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with your own credentials:
-
-```bash
-export OPENROUTER_MANAGEMENT_KEY=...
-export OPENROUTER_ORG_ID=...
-
-focus-exporter --provider openrouter --month 2026-07 --format json
-```
-
-5. Send the output to CostGraph, quoting the connection id and API key.
-
-Every environment variable and the full FOCUS field mapping are documented in the
-[OpenRouter exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openrouter.md).
+4. Run the exporter with `--provider openrouter`, following the
+   [OpenRouter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openrouter.md) for the environment it needs.
+5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/openrouter.mdx
+++ b/costgraph/integrations/openrouter.mdx
@@ -1,0 +1,81 @@
+---
+title: OpenRouter
+description: "Bring OpenRouter cost into CostGraph, pulled by us or pushed by you"
+---
+
+OpenRouter routes requests to many upstream models. One connection captures credit spend across every model and provider you route through it.
+
+CostGraph reads OpenRouter as **FOCUS 1.2** records at a grain of day x model x upstream provider (credit spend).
+
+## Choose how the data reaches us
+
+<CardGroup cols={2}>
+  <Card title="CostGraph pulls it" icon="cloud-arrow-down">
+    You give us read-only credentials and we call OpenRouter once a day. Fastest to set
+    up, and nothing to run.
+  </Card>
+  <Card title="You push it" icon="cloud-arrow-up">
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
+    infrastructure and send us the records. Credentials never leave your side.
+  </Card>
+</CardGroup>
+
+## Permissions
+
+Create a **management key** at openrouter.ai/settings/management-keys.
+
+<Warning>
+A normal `sk-or-v1-` inference key returns `403 - Only management keys can perform this operation`.
+</Warning>
+
+CostGraph only ever reads. The exact endpoints called are listed in the
+[OpenRouter exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openrouter.md).
+
+## Values you will need
+
+| Variable | Required | Kind |
+|----------|----------|------|
+| `OPENROUTER_MANAGEMENT_KEY` | Yes | Credential |
+| `OPENROUTER_ORG_ID` | Yes | Identifier |
+
+## Option 1: let CostGraph pull
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **OpenRouter** and name the connection.
+3. Enter the billing account these charges belong to, then fill in:
+   - `OPENROUTER_MANAGEMENT_KEY`
+   - `OPENROUTER_ORG_ID`
+4. Select **Connect**.
+
+CostGraph runs a short verification fetch before saving, so a wrong value or a
+missing permission fails immediately rather than silently at the next sync.
+
+<Note>
+Credentials are encrypted at rest and used only to read billing data. Revoke them in
+OpenRouter at any time and the connection stops; nothing else is affected.
+</Note>
+
+## Option 2: push it yourself
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+2. Create the connection and copy its **Connection ID**.
+3. Create a CostGraph API key with the `focus:write` scope.
+4. Run the exporter with your own credentials:
+
+```bash
+export OPENROUTER_MANAGEMENT_KEY=...
+export OPENROUTER_ORG_ID=...
+
+focus-exporter --provider openrouter --month 2026-07 --format json
+```
+
+5. Send the output to CostGraph, quoting the connection id and API key.
+
+Every environment variable and the full FOCUS field mapping are documented in the
+[OpenRouter exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openrouter.md).
+
+## What CostGraph does with it
+
+Records land as raw billing rows, are normalised into line items, and roll up into
+daily cost. From there OpenRouter spend appears in Cost Overview and in anomaly
+detection alongside every other provider.

--- a/costgraph/integrations/respanai.mdx
+++ b/costgraph/integrations/respanai.mdx
@@ -1,0 +1,82 @@
+---
+title: RespanAI
+description: "Bring RespanAI cost into CostGraph, pulled by us or pushed by you"
+---
+
+RespanAI is an LLM gateway and observability layer, so one connection captures request spend across every model and upstream provider you route through it.
+
+Formerly KeywordsAI.
+
+CostGraph reads RespanAI as **FOCUS 1.2** records at a grain of day x model x upstream provider (request spend).
+
+## Choose how the data reaches us
+
+<CardGroup cols={2}>
+  <Card title="CostGraph pulls it" icon="cloud-arrow-down">
+    You give us read-only credentials and we call RespanAI once a day. Fastest to set
+    up, and nothing to run.
+  </Card>
+  <Card title="You push it" icon="cloud-arrow-up">
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
+    infrastructure and send us the records. Credentials never leave your side.
+  </Card>
+</CardGroup>
+
+## Permissions
+
+Create an API key in RespanAI. It is sent as a bearer token and only reads request logs.
+
+CostGraph only ever reads. The exact endpoints called are listed in the
+[RespanAI exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/respanai.md).
+
+## Values you will need
+
+| Variable | Required | Kind |
+|----------|----------|------|
+| `RESPANAI_API_KEY` | Yes | Credential |
+| `RESPANAI_ORG_ID` | Yes | Identifier |
+| `RESPANAI_TENANT_FIELD` | No | Identifier |
+
+## Option 1: let CostGraph pull
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **RespanAI** and name the connection.
+3. Enter the billing account these charges belong to, then fill in:
+   - `RESPANAI_API_KEY`
+   - `RESPANAI_ORG_ID`
+   - `RESPANAI_TENANT_FIELD`
+4. Select **Connect**.
+
+CostGraph runs a short verification fetch before saving, so a wrong value or a
+missing permission fails immediately rather than silently at the next sync.
+
+<Note>
+Credentials are encrypted at rest and used only to read billing data. Revoke them in
+RespanAI at any time and the connection stops; nothing else is affected.
+</Note>
+
+## Option 2: push it yourself
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+2. Create the connection and copy its **Connection ID**.
+3. Create a CostGraph API key with the `focus:write` scope.
+4. Run the exporter with your own credentials:
+
+```bash
+export RESPANAI_API_KEY=...
+export RESPANAI_ORG_ID=...
+export RESPANAI_TENANT_FIELD=...
+
+focus-exporter --provider respanai --month 2026-07 --format json
+```
+
+5. Send the output to CostGraph, quoting the connection id and API key.
+
+Every environment variable and the full FOCUS field mapping are documented in the
+[RespanAI exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/respanai.md).
+
+## What CostGraph does with it
+
+Records land as raw billing rows, are normalised into line items, and roll up into
+daily cost. From there RespanAI spend appears in Cost Overview and in anomaly
+detection alongside every other provider.

--- a/costgraph/integrations/respanai.mdx
+++ b/costgraph/integrations/respanai.mdx
@@ -9,71 +9,50 @@ Formerly KeywordsAI.
 
 CostGraph reads RespanAI as **FOCUS 1.2** records at a grain of day x model x upstream provider (request spend).
 
+<Card title="RespanAI reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/respanai.md">
+  The credentials and permissions RespanAI needs, every environment variable, the API
+  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
+  never drifts from the code.
+</Card>
+
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
   <Card title="CostGraph pulls it" icon="cloud-arrow-down">
-    You give us read-only credentials and we call RespanAI once a day. Fastest to set
-    up, and nothing to run.
+    You supply read-only credentials and we call RespanAI once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
-    infrastructure and send us the records. Credentials never leave your side.
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
+    Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
-## Permissions
+## Let CostGraph pull
 
-Create an API key in RespanAI. It is sent as a bearer token and only reads request logs.
-
-CostGraph only ever reads. The exact endpoints called are listed in the
-[RespanAI exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/respanai.md).
-
-## Values you will need
-
-| Variable | Required | Kind |
-|----------|----------|------|
-| `RESPANAI_API_KEY` | Yes | Credential |
-| `RESPANAI_ORG_ID` | Yes | Identifier |
-| `RESPANAI_TENANT_FIELD` | No | Identifier |
-
-## Option 1: let CostGraph pull
-
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
-2. Choose **RespanAI** and name the connection.
-3. Enter the billing account these charges belong to, then fill in:
-   - `RESPANAI_API_KEY`
-   - `RESPANAI_ORG_ID`
-   - `RESPANAI_TENANT_FIELD`
+1. Open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **RespanAI**, name the connection, and enter the billing account these
+   charges belong to.
+3. Fill in the values the form asks for. It lists exactly the variables RespanAI
+   needs, marks which are optional, and links this provider's reference for the
+   permissions each one requires.
 4. Select **Connect**.
 
-CostGraph runs a short verification fetch before saving, so a wrong value or a
-missing permission fails immediately rather than silently at the next sync.
+CostGraph verifies the credentials with a short fetch before saving, so a wrong
+value or a missing permission fails while you are still on the form.
 
 <Note>
 Credentials are encrypted at rest and used only to read billing data. Revoke them in
 RespanAI at any time and the connection stops; nothing else is affected.
 </Note>
 
-## Option 2: push it yourself
+## Push it yourself
 
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with your own credentials:
-
-```bash
-export RESPANAI_API_KEY=...
-export RESPANAI_ORG_ID=...
-export RESPANAI_TENANT_FIELD=...
-
-focus-exporter --provider respanai --month 2026-07 --format json
-```
-
-5. Send the output to CostGraph, quoting the connection id and API key.
-
-Every environment variable and the full FOCUS field mapping are documented in the
-[RespanAI exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/respanai.md).
+4. Run the exporter with `--provider respanai`, following the
+   [RespanAI reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/respanai.md) for the environment it needs.
+5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it
 

--- a/docs.json
+++ b/docs.json
@@ -64,9 +64,16 @@
             "group": "Integrations",
             "icon": "plug",
             "pages": [
-              "costgraph/integrations/planetscale",
+              "costgraph/integrations/anthropic",
+              "costgraph/integrations/aws",
+              "costgraph/integrations/confluent",
               "costgraph/integrations/gcp",
-              "costgraph/integrations/aws"
+              "costgraph/integrations/helicone",
+              "costgraph/integrations/modal",
+              "costgraph/integrations/openai",
+              "costgraph/integrations/openrouter",
+              "costgraph/integrations/planetscale",
+              "costgraph/integrations/respanai"
             ]
           }
         ]

--- a/docs.json
+++ b/docs.json
@@ -58,6 +58,14 @@
               "costgraph/mcp/install",
               "costgraph/mcp/usage"
             ]
+          },
+          {
+            "group": "Integrations",
+            "icon": "plug",
+            "pages": [
+              "costgraph/integrations/gcp",
+              "costgraph/integrations/aws"
+            ]
           }
         ]
       },


### PR DESCRIPTION
Onboarding docs for Costgraph Cloud FOCUS billing integrations.

- **GCP** (`costgraph/integrations/gcp`): enable FOCUS + Detailed exports (Console-only - Google has no API/Terraform for the toggle), grant read via keyless impersonation (recommended) or SA key. Notes the immutable Google-managed dataset + why not OAuth.
- **AWS** (`costgraph/integrations/aws`): fully API/Terraform-automatable FOCUS 1.2 Data Export to S3 (includes the `aws_bcmdataexports_export` Terraform + bucket policy).
- Adds an Integrations nav group.

Reflects the verified onboarding asymmetry: AWS automatable end-to-end, GCP one guided Console click.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added setup and connection guidance for AWS cost data ingestion from S3.
  * Added Google Cloud integration guidance for FOCUS and detailed usage cost exports.
  * Documented required permissions, authentication, infrastructure automation boundaries, reconciliation, and cost allocation behavior.
  * Added AWS and GCP integration pages to the CostGraph documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->