### PR TITLE
Setup guides for every FOCUS provider

### DIFF
--- a/costgraph/integrations/anthropic.mdx
+++ b/costgraph/integrations/anthropic.mdx
@@ -3,79 +3,54 @@ title: Anthropic
 description: "Bring Anthropic cost into CostGraph, pulled by us or pushed by you"
 ---
 
-Anthropic bills API usage per model and token bucket. CostGraph reads the organization usage and cost reports so model spend sits beside your infrastructure cost.
+Anthropic bills API usage per model and token bucket, so model spend lands beside your infrastructure cost.
 
 CostGraph reads Anthropic as **FOCUS 1.2** records at a grain of day x model x token bucket (cost + tokens).
+
+<Card title="Anthropic reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/anthropic.md">
+  The credentials and permissions Anthropic needs, every environment variable, the API
+  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
+  never drifts from the code.
+</Card>
 
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
   <Card title="CostGraph pulls it" icon="cloud-arrow-down">
-    You give us read-only credentials and we call Anthropic once a day. Fastest to set
-    up, and nothing to run.
+    You supply read-only credentials and we call Anthropic once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
-    infrastructure and send us the records. Credentials never leave your side.
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
+    Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
-## Permissions
+## Let CostGraph pull
 
-Create an **Admin key** as an organization admin (Console -> Settings -> Admin keys). Admin keys are distinct from regular API keys and grant read access to organization-wide usage and cost.
-
-<Warning>
-A regular API key will not authenticate against the usage and cost endpoints.
-</Warning>
-
-CostGraph only ever reads. The exact endpoints called are listed in the
-[Anthropic exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/anthropic.md).
-
-## Values you will need
-
-| Variable | Required | Kind |
-|----------|----------|------|
-| `ANTHROPIC_ADMIN_KEY` | Yes | Credential |
-| `ANTHROPIC_ORG_ID` | No | Identifier |
-| `ANTHROPIC_TENANT_GROUP` | No | Identifier |
-
-## Option 1: let CostGraph pull
-
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
-2. Choose **Anthropic** and name the connection.
-3. Enter the billing account these charges belong to, then fill in:
-   - `ANTHROPIC_ADMIN_KEY`
-   - `ANTHROPIC_ORG_ID`
-   - `ANTHROPIC_TENANT_GROUP`
+1. Open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **Anthropic**, name the connection, and enter the billing account these
+   charges belong to.
+3. Fill in the values the form asks for. It lists exactly the variables Anthropic
+   needs, marks which are optional, and links this provider's reference for the
+   permissions each one requires.
 4. Select **Connect**.
 
-CostGraph runs a short verification fetch before saving, so a wrong value or a
-missing permission fails immediately rather than silently at the next sync.
+CostGraph verifies the credentials with a short fetch before saving, so a wrong
+value or a missing permission fails while you are still on the form.
 
 <Note>
 Credentials are encrypted at rest and used only to read billing data. Revoke them in
 Anthropic at any time and the connection stops; nothing else is affected.
 </Note>
 
-## Option 2: push it yourself
+## Push it yourself
 
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with your own credentials:
-
-```bash
-export ANTHROPIC_ADMIN_KEY=...
-export ANTHROPIC_ORG_ID=...
-export ANTHROPIC_TENANT_GROUP=...
-
-focus-exporter --provider anthropic --month 2026-07 --format json
-```
-
-5. Send the output to CostGraph, quoting the connection id and API key.
-
-Every environment variable and the full FOCUS field mapping are documented in the
-[Anthropic exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/anthropic.md).
+4. Run the exporter with `--provider anthropic`, following the
+   [Anthropic reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/anthropic.md) for the environment it needs.
+5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/anthropic.mdx
+++ b/costgraph/integrations/anthropic.mdx
@@ -1,0 +1,84 @@
+---
+title: Anthropic
+description: "Bring Anthropic cost into CostGraph, pulled by us or pushed by you"
+---
+
+Anthropic bills API usage per model and token bucket. CostGraph reads the organization usage and cost reports so model spend sits beside your infrastructure cost.
+
+CostGraph reads Anthropic as **FOCUS 1.2** records at a grain of day x model x token bucket (cost + tokens).
+
+## Choose how the data reaches us
+
+<CardGroup cols={2}>
+  <Card title="CostGraph pulls it" icon="cloud-arrow-down">
+    You give us read-only credentials and we call Anthropic once a day. Fastest to set
+    up, and nothing to run.
+  </Card>
+  <Card title="You push it" icon="cloud-arrow-up">
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
+    infrastructure and send us the records. Credentials never leave your side.
+  </Card>
+</CardGroup>
+
+## Permissions
+
+Create an **Admin key** as an organization admin (Console -> Settings -> Admin keys). Admin keys are distinct from regular API keys and grant read access to organization-wide usage and cost.
+
+<Warning>
+A regular API key will not authenticate against the usage and cost endpoints.
+</Warning>
+
+CostGraph only ever reads. The exact endpoints called are listed in the
+[Anthropic exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/anthropic.md).
+
+## Values you will need
+
+| Variable | Required | Kind |
+|----------|----------|------|
+| `ANTHROPIC_ADMIN_KEY` | Yes | Credential |
+| `ANTHROPIC_ORG_ID` | No | Identifier |
+| `ANTHROPIC_TENANT_GROUP` | No | Identifier |
+
+## Option 1: let CostGraph pull
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **Anthropic** and name the connection.
+3. Enter the billing account these charges belong to, then fill in:
+   - `ANTHROPIC_ADMIN_KEY`
+   - `ANTHROPIC_ORG_ID`
+   - `ANTHROPIC_TENANT_GROUP`
+4. Select **Connect**.
+
+CostGraph runs a short verification fetch before saving, so a wrong value or a
+missing permission fails immediately rather than silently at the next sync.
+
+<Note>
+Credentials are encrypted at rest and used only to read billing data. Revoke them in
+Anthropic at any time and the connection stops; nothing else is affected.
+</Note>
+
+## Option 2: push it yourself
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+2. Create the connection and copy its **Connection ID**.
+3. Create a CostGraph API key with the `focus:write` scope.
+4. Run the exporter with your own credentials:
+
+```bash
+export ANTHROPIC_ADMIN_KEY=...
+export ANTHROPIC_ORG_ID=...
+export ANTHROPIC_TENANT_GROUP=...
+
+focus-exporter --provider anthropic --month 2026-07 --format json
+```
+
+5. Send the output to CostGraph, quoting the connection id and API key.
+
+Every environment variable and the full FOCUS field mapping are documented in the
+[Anthropic exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/anthropic.md).
+
+## What CostGraph does with it
+
+Records land as raw billing rows, are normalised into line items, and roll up into
+daily cost. From there Anthropic spend appears in Cost Overview and in anomaly
+detection alongside every other provider.

--- a/costgraph/integrations/confluent.mdx
+++ b/costgraph/integrations/confluent.mdx
@@ -1,0 +1,84 @@
+---
+title: Confluent Cloud
+description: "Bring Confluent Cloud cost into CostGraph, pulled by us or pushed by you"
+---
+
+Confluent Cloud bills per product and resource. CostGraph reads the billing API so Kafka spend is attributed per cluster and environment.
+
+CostGraph reads Confluent Cloud as **FOCUS 1.2** records at a grain of billing line item (product x resource).
+
+## Choose how the data reaches us
+
+<CardGroup cols={2}>
+  <Card title="CostGraph pulls it" icon="cloud-arrow-down">
+    You give us read-only credentials and we call Confluent Cloud once a day. Fastest to set
+    up, and nothing to run.
+  </Card>
+  <Card title="You push it" icon="cloud-arrow-up">
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
+    infrastructure and send us the records. Credentials never leave your side.
+  </Card>
+</CardGroup>
+
+## Permissions
+
+Create a **Cloud API key** (org-scoped, not a cluster or resource key) whose owner holds the **OrganizationAdmin** or **BillingAdmin** role.
+
+<Warning>
+A resource-scoped key, or a key without a billing role, returns `403`.
+</Warning>
+
+CostGraph only ever reads. The exact endpoints called are listed in the
+[Confluent Cloud exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/confluent.md).
+
+## Values you will need
+
+| Variable | Required | Kind |
+|----------|----------|------|
+| `CONFLUENT_CLOUD_API_KEY` | Yes | Credential |
+| `CONFLUENT_CLOUD_API_SECRET` | Yes | Credential |
+| `CONFLUENT_ORG_ID` | Yes | Identifier |
+
+## Option 1: let CostGraph pull
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **Confluent Cloud** and name the connection.
+3. Enter the billing account these charges belong to, then fill in:
+   - `CONFLUENT_CLOUD_API_KEY`
+   - `CONFLUENT_CLOUD_API_SECRET`
+   - `CONFLUENT_ORG_ID`
+4. Select **Connect**.
+
+CostGraph runs a short verification fetch before saving, so a wrong value or a
+missing permission fails immediately rather than silently at the next sync.
+
+<Note>
+Credentials are encrypted at rest and used only to read billing data. Revoke them in
+Confluent Cloud at any time and the connection stops; nothing else is affected.
+</Note>
+
+## Option 2: push it yourself
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+2. Create the connection and copy its **Connection ID**.
+3. Create a CostGraph API key with the `focus:write` scope.
+4. Run the exporter with your own credentials:
+
+```bash
+export CONFLUENT_CLOUD_API_KEY=...
+export CONFLUENT_CLOUD_API_SECRET=...
+export CONFLUENT_ORG_ID=...
+
+focus-exporter --provider confluent --month 2026-07 --format json
+```
+
+5. Send the output to CostGraph, quoting the connection id and API key.
+
+Every environment variable and the full FOCUS field mapping are documented in the
+[Confluent Cloud exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/confluent.md).
+
+## What CostGraph does with it
+
+Records land as raw billing rows, are normalised into line items, and roll up into
+daily cost. From there Confluent Cloud spend appears in Cost Overview and in anomaly
+detection alongside every other provider.

--- a/costgraph/integrations/confluent.mdx
+++ b/costgraph/integrations/confluent.mdx
@@ -3,79 +3,54 @@ title: Confluent Cloud
 description: "Bring Confluent Cloud cost into CostGraph, pulled by us or pushed by you"
 ---
 
-Confluent Cloud bills per product and resource. CostGraph reads the billing API so Kafka spend is attributed per cluster and environment.
+Confluent Cloud bills per product and resource, so Kafka spend is attributed per cluster and environment.
 
 CostGraph reads Confluent Cloud as **FOCUS 1.2** records at a grain of billing line item (product x resource).
+
+<Card title="Confluent Cloud reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/confluent.md">
+  The credentials and permissions Confluent Cloud needs, every environment variable, the API
+  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
+  never drifts from the code.
+</Card>
 
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
   <Card title="CostGraph pulls it" icon="cloud-arrow-down">
-    You give us read-only credentials and we call Confluent Cloud once a day. Fastest to set
-    up, and nothing to run.
+    You supply read-only credentials and we call Confluent Cloud once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
-    infrastructure and send us the records. Credentials never leave your side.
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
+    Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
-## Permissions
+## Let CostGraph pull
 
-Create a **Cloud API key** (org-scoped, not a cluster or resource key) whose owner holds the **OrganizationAdmin** or **BillingAdmin** role.
-
-<Warning>
-A resource-scoped key, or a key without a billing role, returns `403`.
-</Warning>
-
-CostGraph only ever reads. The exact endpoints called are listed in the
-[Confluent Cloud exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/confluent.md).
-
-## Values you will need
-
-| Variable | Required | Kind |
-|----------|----------|------|
-| `CONFLUENT_CLOUD_API_KEY` | Yes | Credential |
-| `CONFLUENT_CLOUD_API_SECRET` | Yes | Credential |
-| `CONFLUENT_ORG_ID` | Yes | Identifier |
-
-## Option 1: let CostGraph pull
-
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
-2. Choose **Confluent Cloud** and name the connection.
-3. Enter the billing account these charges belong to, then fill in:
-   - `CONFLUENT_CLOUD_API_KEY`
-   - `CONFLUENT_CLOUD_API_SECRET`
-   - `CONFLUENT_ORG_ID`
+1. Open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **Confluent Cloud**, name the connection, and enter the billing account these
+   charges belong to.
+3. Fill in the values the form asks for. It lists exactly the variables Confluent Cloud
+   needs, marks which are optional, and links this provider's reference for the
+   permissions each one requires.
 4. Select **Connect**.
 
-CostGraph runs a short verification fetch before saving, so a wrong value or a
-missing permission fails immediately rather than silently at the next sync.
+CostGraph verifies the credentials with a short fetch before saving, so a wrong
+value or a missing permission fails while you are still on the form.
 
 <Note>
 Credentials are encrypted at rest and used only to read billing data. Revoke them in
 Confluent Cloud at any time and the connection stops; nothing else is affected.
 </Note>
 
-## Option 2: push it yourself
+## Push it yourself
 
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with your own credentials:
-
-```bash
-export CONFLUENT_CLOUD_API_KEY=...
-export CONFLUENT_CLOUD_API_SECRET=...
-export CONFLUENT_ORG_ID=...
-
-focus-exporter --provider confluent --month 2026-07 --format json
-```
-
-5. Send the output to CostGraph, quoting the connection id and API key.
-
-Every environment variable and the full FOCUS field mapping are documented in the
-[Confluent Cloud exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/confluent.md).
+4. Run the exporter with `--provider confluent`, following the
+   [Confluent Cloud reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/confluent.md) for the environment it needs.
+5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/helicone.mdx
+++ b/costgraph/integrations/helicone.mdx
@@ -1,0 +1,80 @@
+---
+title: Helicone
+description: "Bring Helicone cost into CostGraph, pulled by us or pushed by you"
+---
+
+Helicone is an LLM gateway, so one connection captures spend across every model and upstream provider you route through it.
+
+CostGraph reads Helicone as **FOCUS 1.2** records at a grain of day x model x upstream provider (request spend).
+
+## Choose how the data reaches us
+
+<CardGroup cols={2}>
+  <Card title="CostGraph pulls it" icon="cloud-arrow-down">
+    You give us read-only credentials and we call Helicone once a day. Fastest to set
+    up, and nothing to run.
+  </Card>
+  <Card title="You push it" icon="cloud-arrow-up">
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
+    infrastructure and send us the records. Credentials never leave your side.
+  </Card>
+</CardGroup>
+
+## Permissions
+
+Create an API key (`sk-helicone-...`) in Helicone. It is sent as a bearer token and only reads request logs.
+
+CostGraph only ever reads. The exact endpoints called are listed in the
+[Helicone exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/helicone.md).
+
+## Values you will need
+
+| Variable | Required | Kind |
+|----------|----------|------|
+| `HELICONE_API_KEY` | Yes | Credential |
+| `HELICONE_ORG_ID` | Yes | Identifier |
+| `HELICONE_TENANT_PROPERTY` | No | Identifier |
+
+## Option 1: let CostGraph pull
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **Helicone** and name the connection.
+3. Enter the billing account these charges belong to, then fill in:
+   - `HELICONE_API_KEY`
+   - `HELICONE_ORG_ID`
+   - `HELICONE_TENANT_PROPERTY`
+4. Select **Connect**.
+
+CostGraph runs a short verification fetch before saving, so a wrong value or a
+missing permission fails immediately rather than silently at the next sync.
+
+<Note>
+Credentials are encrypted at rest and used only to read billing data. Revoke them in
+Helicone at any time and the connection stops; nothing else is affected.
+</Note>
+
+## Option 2: push it yourself
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+2. Create the connection and copy its **Connection ID**.
+3. Create a CostGraph API key with the `focus:write` scope.
+4. Run the exporter with your own credentials:
+
+```bash
+export HELICONE_API_KEY=...
+export HELICONE_ORG_ID=...
+export HELICONE_TENANT_PROPERTY=...
+
+focus-exporter --provider helicone --month 2026-07 --format json
+```
+
+5. Send the output to CostGraph, quoting the connection id and API key.
+
+Every environment variable and the full FOCUS field mapping are documented in the
+[Helicone exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/helicone.md).
+
+## What CostGraph does with it
+
+Records land as raw billing rows, are normalised into line items, and roll up into
+daily cost. From there Helicone spend appears in Cost Overview and in anomaly
+detection alongside every other provider.

--- a/costgraph/integrations/helicone.mdx
+++ b/costgraph/integrations/helicone.mdx
@@ -7,71 +7,50 @@ Helicone is an LLM gateway, so one connection captures spend across every model 
 
 CostGraph reads Helicone as **FOCUS 1.2** records at a grain of day x model x upstream provider (request spend).
 
+<Card title="Helicone reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/helicone.md">
+  The credentials and permissions Helicone needs, every environment variable, the API
+  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
+  never drifts from the code.
+</Card>
+
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
   <Card title="CostGraph pulls it" icon="cloud-arrow-down">
-    You give us read-only credentials and we call Helicone once a day. Fastest to set
-    up, and nothing to run.
+    You supply read-only credentials and we call Helicone once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
-    infrastructure and send us the records. Credentials never leave your side.
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
+    Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
-## Permissions
+## Let CostGraph pull
 
-Create an API key (`sk-helicone-...`) in Helicone. It is sent as a bearer token and only reads request logs.
-
-CostGraph only ever reads. The exact endpoints called are listed in the
-[Helicone exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/helicone.md).
-
-## Values you will need
-
-| Variable | Required | Kind |
-|----------|----------|------|
-| `HELICONE_API_KEY` | Yes | Credential |
-| `HELICONE_ORG_ID` | Yes | Identifier |
-| `HELICONE_TENANT_PROPERTY` | No | Identifier |
-
-## Option 1: let CostGraph pull
-
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
-2. Choose **Helicone** and name the connection.
-3. Enter the billing account these charges belong to, then fill in:
-   - `HELICONE_API_KEY`
-   - `HELICONE_ORG_ID`
-   - `HELICONE_TENANT_PROPERTY`
+1. Open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **Helicone**, name the connection, and enter the billing account these
+   charges belong to.
+3. Fill in the values the form asks for. It lists exactly the variables Helicone
+   needs, marks which are optional, and links this provider's reference for the
+   permissions each one requires.
 4. Select **Connect**.
 
-CostGraph runs a short verification fetch before saving, so a wrong value or a
-missing permission fails immediately rather than silently at the next sync.
+CostGraph verifies the credentials with a short fetch before saving, so a wrong
+value or a missing permission fails while you are still on the form.
 
 <Note>
 Credentials are encrypted at rest and used only to read billing data. Revoke them in
 Helicone at any time and the connection stops; nothing else is affected.
 </Note>
 
-## Option 2: push it yourself
+## Push it yourself
 
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with your own credentials:
-
-```bash
-export HELICONE_API_KEY=...
-export HELICONE_ORG_ID=...
-export HELICONE_TENANT_PROPERTY=...
-
-focus-exporter --provider helicone --month 2026-07 --format json
-```
-
-5. Send the output to CostGraph, quoting the connection id and API key.
-
-Every environment variable and the full FOCUS field mapping are documented in the
-[Helicone exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/helicone.md).
+4. Run the exporter with `--provider helicone`, following the
+   [Helicone reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/helicone.md) for the environment it needs.
+5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/modal.mdx
+++ b/costgraph/integrations/modal.mdx
@@ -3,75 +3,54 @@ title: Modal
 description: "Bring Modal cost into CostGraph, pulled by us or pushed by you"
 ---
 
-Modal bills serverless GPU and compute per object. CostGraph reads the usage API so per-function CPU, memory, and GPU cost is attributed.
+Modal bills serverless GPU and compute per object, so per-function CPU, memory, and GPU cost is attributed.
 
 CostGraph reads Modal as **FOCUS 1.2** records at a grain of day x object (per-resource CPU/mem/GPU cost).
+
+<Card title="Modal reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/modal.md">
+  The credentials and permissions Modal needs, every environment variable, the API
+  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
+  never drifts from the code.
+</Card>
 
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
   <Card title="CostGraph pulls it" icon="cloud-arrow-down">
-    You give us read-only credentials and we call Modal once a day. Fastest to set
-    up, and nothing to run.
+    You supply read-only credentials and we call Modal once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
-    infrastructure and send us the records. Credentials never leave your side.
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
+    Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
-## Permissions
+## Let CostGraph pull
 
-Create a token with `modal token new`. It is sent as gRPC metadata and only reads usage.
-
-CostGraph only ever reads. The exact endpoints called are listed in the
-[Modal exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/modal.md).
-
-## Values you will need
-
-| Variable | Required | Kind |
-|----------|----------|------|
-| `MODAL_TOKEN_ID` | Yes | Credential |
-| `MODAL_TOKEN_SECRET` | Yes | Credential |
-| `MODAL_WORKSPACE_ID` | Yes | Identifier |
-
-## Option 1: let CostGraph pull
-
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
-2. Choose **Modal** and name the connection.
-3. Enter the billing account these charges belong to, then fill in:
-   - `MODAL_TOKEN_ID`
-   - `MODAL_TOKEN_SECRET`
-   - `MODAL_WORKSPACE_ID`
+1. Open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **Modal**, name the connection, and enter the billing account these
+   charges belong to.
+3. Fill in the values the form asks for. It lists exactly the variables Modal
+   needs, marks which are optional, and links this provider's reference for the
+   permissions each one requires.
 4. Select **Connect**.
 
-CostGraph runs a short verification fetch before saving, so a wrong value or a
-missing permission fails immediately rather than silently at the next sync.
+CostGraph verifies the credentials with a short fetch before saving, so a wrong
+value or a missing permission fails while you are still on the form.
 
 <Note>
 Credentials are encrypted at rest and used only to read billing data. Revoke them in
 Modal at any time and the connection stops; nothing else is affected.
 </Note>
 
-## Option 2: push it yourself
+## Push it yourself
 
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with your own credentials:
-
-```bash
-export MODAL_TOKEN_ID=...
-export MODAL_TOKEN_SECRET=...
-export MODAL_WORKSPACE_ID=...
-
-focus-exporter --provider modal --month 2026-07 --format json
-```
-
-5. Send the output to CostGraph, quoting the connection id and API key.
-
-Every environment variable and the full FOCUS field mapping are documented in the
-[Modal exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/modal.md).
+4. Run the exporter with `--provider modal`, following the
+   [Modal reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/modal.md) for the environment it needs.
+5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/modal.mdx
+++ b/costgraph/integrations/modal.mdx
@@ -1,0 +1,80 @@
+---
+title: Modal
+description: "Bring Modal cost into CostGraph, pulled by us or pushed by you"
+---
+
+Modal bills serverless GPU and compute per object. CostGraph reads the usage API so per-function CPU, memory, and GPU cost is attributed.
+
+CostGraph reads Modal as **FOCUS 1.2** records at a grain of day x object (per-resource CPU/mem/GPU cost).
+
+## Choose how the data reaches us
+
+<CardGroup cols={2}>
+  <Card title="CostGraph pulls it" icon="cloud-arrow-down">
+    You give us read-only credentials and we call Modal once a day. Fastest to set
+    up, and nothing to run.
+  </Card>
+  <Card title="You push it" icon="cloud-arrow-up">
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
+    infrastructure and send us the records. Credentials never leave your side.
+  </Card>
+</CardGroup>
+
+## Permissions
+
+Create a token with `modal token new`. It is sent as gRPC metadata and only reads usage.
+
+CostGraph only ever reads. The exact endpoints called are listed in the
+[Modal exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/modal.md).
+
+## Values you will need
+
+| Variable | Required | Kind |
+|----------|----------|------|
+| `MODAL_TOKEN_ID` | Yes | Credential |
+| `MODAL_TOKEN_SECRET` | Yes | Credential |
+| `MODAL_WORKSPACE_ID` | Yes | Identifier |
+
+## Option 1: let CostGraph pull
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **Modal** and name the connection.
+3. Enter the billing account these charges belong to, then fill in:
+   - `MODAL_TOKEN_ID`
+   - `MODAL_TOKEN_SECRET`
+   - `MODAL_WORKSPACE_ID`
+4. Select **Connect**.
+
+CostGraph runs a short verification fetch before saving, so a wrong value or a
+missing permission fails immediately rather than silently at the next sync.
+
+<Note>
+Credentials are encrypted at rest and used only to read billing data. Revoke them in
+Modal at any time and the connection stops; nothing else is affected.
+</Note>
+
+## Option 2: push it yourself
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+2. Create the connection and copy its **Connection ID**.
+3. Create a CostGraph API key with the `focus:write` scope.
+4. Run the exporter with your own credentials:
+
+```bash
+export MODAL_TOKEN_ID=...
+export MODAL_TOKEN_SECRET=...
+export MODAL_WORKSPACE_ID=...
+
+focus-exporter --provider modal --month 2026-07 --format json
+```
+
+5. Send the output to CostGraph, quoting the connection id and API key.
+
+Every environment variable and the full FOCUS field mapping are documented in the
+[Modal exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/modal.md).
+
+## What CostGraph does with it
+
+Records land as raw billing rows, are normalised into line items, and roll up into
+daily cost. From there Modal spend appears in Cost Overview and in anomaly
+detection alongside every other provider.

--- a/costgraph/integrations/openai.mdx
+++ b/costgraph/integrations/openai.mdx
@@ -3,79 +3,54 @@ title: OpenAI
 description: "Bring OpenAI cost into CostGraph, pulled by us or pushed by you"
 ---
 
-OpenAI bills API usage per model and token bucket. CostGraph reads the organization usage and cost endpoints so model spend sits beside your infrastructure cost.
+OpenAI bills API usage per model and token bucket, so model spend lands beside your infrastructure cost.
 
 CostGraph reads OpenAI as **FOCUS 1.2** records at a grain of day x model x token bucket (billed cost + quantity).
+
+<Card title="OpenAI reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openai.md">
+  The credentials and permissions OpenAI needs, every environment variable, the API
+  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
+  never drifts from the code.
+</Card>
 
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
   <Card title="CostGraph pulls it" icon="cloud-arrow-down">
-    You give us read-only credentials and we call OpenAI once a day. Fastest to set
-    up, and nothing to run.
+    You supply read-only credentials and we call OpenAI once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
-    infrastructure and send us the records. Credentials never leave your side.
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
+    Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
-## Permissions
+## Let CostGraph pull
 
-Create an **Admin key** (`sk-admin-...`) as an organization owner (Settings -> Organization -> Admin keys), or grant an existing key the **`api.usage.read`** scope.
-
-<Warning>
-A regular or service-account key without that scope returns `403 Missing scopes`.
-</Warning>
-
-CostGraph only ever reads. The exact endpoints called are listed in the
-[OpenAI exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openai.md).
-
-## Values you will need
-
-| Variable | Required | Kind |
-|----------|----------|------|
-| `OPENAI_ADMIN_KEY` | Yes | Credential |
-| `OPENAI_ORG_ID` | Yes | Identifier |
-| `OPENAI_TENANT_GROUP` | No | Identifier |
-
-## Option 1: let CostGraph pull
-
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
-2. Choose **OpenAI** and name the connection.
-3. Enter the billing account these charges belong to, then fill in:
-   - `OPENAI_ADMIN_KEY`
-   - `OPENAI_ORG_ID`
-   - `OPENAI_TENANT_GROUP`
+1. Open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **OpenAI**, name the connection, and enter the billing account these
+   charges belong to.
+3. Fill in the values the form asks for. It lists exactly the variables OpenAI
+   needs, marks which are optional, and links this provider's reference for the
+   permissions each one requires.
 4. Select **Connect**.
 
-CostGraph runs a short verification fetch before saving, so a wrong value or a
-missing permission fails immediately rather than silently at the next sync.
+CostGraph verifies the credentials with a short fetch before saving, so a wrong
+value or a missing permission fails while you are still on the form.
 
 <Note>
 Credentials are encrypted at rest and used only to read billing data. Revoke them in
 OpenAI at any time and the connection stops; nothing else is affected.
 </Note>
 
-## Option 2: push it yourself
+## Push it yourself
 
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with your own credentials:
-
-```bash
-export OPENAI_ADMIN_KEY=...
-export OPENAI_ORG_ID=...
-export OPENAI_TENANT_GROUP=...
-
-focus-exporter --provider openai --month 2026-07 --format json
-```
-
-5. Send the output to CostGraph, quoting the connection id and API key.
-
-Every environment variable and the full FOCUS field mapping are documented in the
-[OpenAI exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openai.md).
+4. Run the exporter with `--provider openai`, following the
+   [OpenAI reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openai.md) for the environment it needs.
+5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/openai.mdx
+++ b/costgraph/integrations/openai.mdx
@@ -1,0 +1,84 @@
+---
+title: OpenAI
+description: "Bring OpenAI cost into CostGraph, pulled by us or pushed by you"
+---
+
+OpenAI bills API usage per model and token bucket. CostGraph reads the organization usage and cost endpoints so model spend sits beside your infrastructure cost.
+
+CostGraph reads OpenAI as **FOCUS 1.2** records at a grain of day x model x token bucket (billed cost + quantity).
+
+## Choose how the data reaches us
+
+<CardGroup cols={2}>
+  <Card title="CostGraph pulls it" icon="cloud-arrow-down">
+    You give us read-only credentials and we call OpenAI once a day. Fastest to set
+    up, and nothing to run.
+  </Card>
+  <Card title="You push it" icon="cloud-arrow-up">
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
+    infrastructure and send us the records. Credentials never leave your side.
+  </Card>
+</CardGroup>
+
+## Permissions
+
+Create an **Admin key** (`sk-admin-...`) as an organization owner (Settings -> Organization -> Admin keys), or grant an existing key the **`api.usage.read`** scope.
+
+<Warning>
+A regular or service-account key without that scope returns `403 Missing scopes`.
+</Warning>
+
+CostGraph only ever reads. The exact endpoints called are listed in the
+[OpenAI exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openai.md).
+
+## Values you will need
+
+| Variable | Required | Kind |
+|----------|----------|------|
+| `OPENAI_ADMIN_KEY` | Yes | Credential |
+| `OPENAI_ORG_ID` | Yes | Identifier |
+| `OPENAI_TENANT_GROUP` | No | Identifier |
+
+## Option 1: let CostGraph pull
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **OpenAI** and name the connection.
+3. Enter the billing account these charges belong to, then fill in:
+   - `OPENAI_ADMIN_KEY`
+   - `OPENAI_ORG_ID`
+   - `OPENAI_TENANT_GROUP`
+4. Select **Connect**.
+
+CostGraph runs a short verification fetch before saving, so a wrong value or a
+missing permission fails immediately rather than silently at the next sync.
+
+<Note>
+Credentials are encrypted at rest and used only to read billing data. Revoke them in
+OpenAI at any time and the connection stops; nothing else is affected.
+</Note>
+
+## Option 2: push it yourself
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+2. Create the connection and copy its **Connection ID**.
+3. Create a CostGraph API key with the `focus:write` scope.
+4. Run the exporter with your own credentials:
+
+```bash
+export OPENAI_ADMIN_KEY=...
+export OPENAI_ORG_ID=...
+export OPENAI_TENANT_GROUP=...
+
+focus-exporter --provider openai --month 2026-07 --format json
+```
+
+5. Send the output to CostGraph, quoting the connection id and API key.
+
+Every environment variable and the full FOCUS field mapping are documented in the
+[OpenAI exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openai.md).
+
+## What CostGraph does with it
+
+Records land as raw billing rows, are normalised into line items, and roll up into
+daily cost. From there OpenAI spend appears in Cost Overview and in anomaly
+detection alongside every other provider.

--- a/costgraph/integrations/openrouter.mdx
+++ b/costgraph/integrations/openrouter.mdx
@@ -3,76 +3,54 @@ title: OpenRouter
 description: "Bring OpenRouter cost into CostGraph, pulled by us or pushed by you"
 ---
 
-OpenRouter routes requests to many upstream models. One connection captures credit spend across every model and provider you route through it.
+OpenRouter routes requests to many upstream models, so one connection captures credit spend across all of them.
 
 CostGraph reads OpenRouter as **FOCUS 1.2** records at a grain of day x model x upstream provider (credit spend).
+
+<Card title="OpenRouter reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openrouter.md">
+  The credentials and permissions OpenRouter needs, every environment variable, the API
+  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
+  never drifts from the code.
+</Card>
 
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
   <Card title="CostGraph pulls it" icon="cloud-arrow-down">
-    You give us read-only credentials and we call OpenRouter once a day. Fastest to set
-    up, and nothing to run.
+    You supply read-only credentials and we call OpenRouter once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
-    infrastructure and send us the records. Credentials never leave your side.
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
+    Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
-## Permissions
+## Let CostGraph pull
 
-Create a **management key** at openrouter.ai/settings/management-keys.
-
-<Warning>
-A normal `sk-or-v1-` inference key returns `403 - Only management keys can perform this operation`.
-</Warning>
-
-CostGraph only ever reads. The exact endpoints called are listed in the
-[OpenRouter exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openrouter.md).
-
-## Values you will need
-
-| Variable | Required | Kind |
-|----------|----------|------|
-| `OPENROUTER_MANAGEMENT_KEY` | Yes | Credential |
-| `OPENROUTER_ORG_ID` | Yes | Identifier |
-
-## Option 1: let CostGraph pull
-
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
-2. Choose **OpenRouter** and name the connection.
-3. Enter the billing account these charges belong to, then fill in:
-   - `OPENROUTER_MANAGEMENT_KEY`
-   - `OPENROUTER_ORG_ID`
+1. Open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **OpenRouter**, name the connection, and enter the billing account these
+   charges belong to.
+3. Fill in the values the form asks for. It lists exactly the variables OpenRouter
+   needs, marks which are optional, and links this provider's reference for the
+   permissions each one requires.
 4. Select **Connect**.
 
-CostGraph runs a short verification fetch before saving, so a wrong value or a
-missing permission fails immediately rather than silently at the next sync.
+CostGraph verifies the credentials with a short fetch before saving, so a wrong
+value or a missing permission fails while you are still on the form.
 
 <Note>
 Credentials are encrypted at rest and used only to read billing data. Revoke them in
 OpenRouter at any time and the connection stops; nothing else is affected.
 </Note>
 
-## Option 2: push it yourself
+## Push it yourself
 
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with your own credentials:
-
-```bash
-export OPENROUTER_MANAGEMENT_KEY=...
-export OPENROUTER_ORG_ID=...
-
-focus-exporter --provider openrouter --month 2026-07 --format json
-```
-
-5. Send the output to CostGraph, quoting the connection id and API key.
-
-Every environment variable and the full FOCUS field mapping are documented in the
-[OpenRouter exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openrouter.md).
+4. Run the exporter with `--provider openrouter`, following the
+   [OpenRouter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openrouter.md) for the environment it needs.
+5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/openrouter.mdx
+++ b/costgraph/integrations/openrouter.mdx
@@ -1,0 +1,81 @@
+---
+title: OpenRouter
+description: "Bring OpenRouter cost into CostGraph, pulled by us or pushed by you"
+---
+
+OpenRouter routes requests to many upstream models. One connection captures credit spend across every model and provider you route through it.
+
+CostGraph reads OpenRouter as **FOCUS 1.2** records at a grain of day x model x upstream provider (credit spend).
+
+## Choose how the data reaches us
+
+<CardGroup cols={2}>
+  <Card title="CostGraph pulls it" icon="cloud-arrow-down">
+    You give us read-only credentials and we call OpenRouter once a day. Fastest to set
+    up, and nothing to run.
+  </Card>
+  <Card title="You push it" icon="cloud-arrow-up">
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
+    infrastructure and send us the records. Credentials never leave your side.
+  </Card>
+</CardGroup>
+
+## Permissions
+
+Create a **management key** at openrouter.ai/settings/management-keys.
+
+<Warning>
+A normal `sk-or-v1-` inference key returns `403 - Only management keys can perform this operation`.
+</Warning>
+
+CostGraph only ever reads. The exact endpoints called are listed in the
+[OpenRouter exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openrouter.md).
+
+## Values you will need
+
+| Variable | Required | Kind |
+|----------|----------|------|
+| `OPENROUTER_MANAGEMENT_KEY` | Yes | Credential |
+| `OPENROUTER_ORG_ID` | Yes | Identifier |
+
+## Option 1: let CostGraph pull
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **OpenRouter** and name the connection.
+3. Enter the billing account these charges belong to, then fill in:
+   - `OPENROUTER_MANAGEMENT_KEY`
+   - `OPENROUTER_ORG_ID`
+4. Select **Connect**.
+
+CostGraph runs a short verification fetch before saving, so a wrong value or a
+missing permission fails immediately rather than silently at the next sync.
+
+<Note>
+Credentials are encrypted at rest and used only to read billing data. Revoke them in
+OpenRouter at any time and the connection stops; nothing else is affected.
+</Note>
+
+## Option 2: push it yourself
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+2. Create the connection and copy its **Connection ID**.
+3. Create a CostGraph API key with the `focus:write` scope.
+4. Run the exporter with your own credentials:
+
+```bash
+export OPENROUTER_MANAGEMENT_KEY=...
+export OPENROUTER_ORG_ID=...
+
+focus-exporter --provider openrouter --month 2026-07 --format json
+```
+
+5. Send the output to CostGraph, quoting the connection id and API key.
+
+Every environment variable and the full FOCUS field mapping are documented in the
+[OpenRouter exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openrouter.md).
+
+## What CostGraph does with it
+
+Records land as raw billing rows, are normalised into line items, and roll up into
+daily cost. From there OpenRouter spend appears in Cost Overview and in anomaly
+detection alongside every other provider.

--- a/costgraph/integrations/respanai.mdx
+++ b/costgraph/integrations/respanai.mdx
@@ -1,0 +1,82 @@
+---
+title: RespanAI
+description: "Bring RespanAI cost into CostGraph, pulled by us or pushed by you"
+---
+
+RespanAI is an LLM gateway and observability layer, so one connection captures request spend across every model and upstream provider you route through it.
+
+Formerly KeywordsAI.
+
+CostGraph reads RespanAI as **FOCUS 1.2** records at a grain of day x model x upstream provider (request spend).
+
+## Choose how the data reaches us
+
+<CardGroup cols={2}>
+  <Card title="CostGraph pulls it" icon="cloud-arrow-down">
+    You give us read-only credentials and we call RespanAI once a day. Fastest to set
+    up, and nothing to run.
+  </Card>
+  <Card title="You push it" icon="cloud-arrow-up">
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
+    infrastructure and send us the records. Credentials never leave your side.
+  </Card>
+</CardGroup>
+
+## Permissions
+
+Create an API key in RespanAI. It is sent as a bearer token and only reads request logs.
+
+CostGraph only ever reads. The exact endpoints called are listed in the
+[RespanAI exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/respanai.md).
+
+## Values you will need
+
+| Variable | Required | Kind |
+|----------|----------|------|
+| `RESPANAI_API_KEY` | Yes | Credential |
+| `RESPANAI_ORG_ID` | Yes | Identifier |
+| `RESPANAI_TENANT_FIELD` | No | Identifier |
+
+## Option 1: let CostGraph pull
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **RespanAI** and name the connection.
+3. Enter the billing account these charges belong to, then fill in:
+   - `RESPANAI_API_KEY`
+   - `RESPANAI_ORG_ID`
+   - `RESPANAI_TENANT_FIELD`
+4. Select **Connect**.
+
+CostGraph runs a short verification fetch before saving, so a wrong value or a
+missing permission fails immediately rather than silently at the next sync.
+
+<Note>
+Credentials are encrypted at rest and used only to read billing data. Revoke them in
+RespanAI at any time and the connection stops; nothing else is affected.
+</Note>
+
+## Option 2: push it yourself
+
+1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+2. Create the connection and copy its **Connection ID**.
+3. Create a CostGraph API key with the `focus:write` scope.
+4. Run the exporter with your own credentials:
+
+```bash
+export RESPANAI_API_KEY=...
+export RESPANAI_ORG_ID=...
+export RESPANAI_TENANT_FIELD=...
+
+focus-exporter --provider respanai --month 2026-07 --format json
+```
+
+5. Send the output to CostGraph, quoting the connection id and API key.
+
+Every environment variable and the full FOCUS field mapping are documented in the
+[RespanAI exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/respanai.md).
+
+## What CostGraph does with it
+
+Records land as raw billing rows, are normalised into line items, and roll up into
+daily cost. From there RespanAI spend appears in Cost Overview and in anomaly
+detection alongside every other provider.

--- a/costgraph/integrations/respanai.mdx
+++ b/costgraph/integrations/respanai.mdx
@@ -9,71 +9,50 @@ Formerly KeywordsAI.
 
 CostGraph reads RespanAI as **FOCUS 1.2** records at a grain of day x model x upstream provider (request spend).
 
+<Card title="RespanAI reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/respanai.md">
+  The credentials and permissions RespanAI needs, every environment variable, the API
+  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
+  never drifts from the code.
+</Card>
+
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
   <Card title="CostGraph pulls it" icon="cloud-arrow-down">
-    You give us read-only credentials and we call RespanAI once a day. Fastest to set
-    up, and nothing to run.
+    You supply read-only credentials and we call RespanAI once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) in your own
-    infrastructure and send us the records. Credentials never leave your side.
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
+    Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
-## Permissions
+## Let CostGraph pull
 
-Create an API key in RespanAI. It is sent as a bearer token and only reads request logs.
-
-CostGraph only ever reads. The exact endpoints called are listed in the
-[RespanAI exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/respanai.md).
-
-## Values you will need
-
-| Variable | Required | Kind |
-|----------|----------|------|
-| `RESPANAI_API_KEY` | Yes | Credential |
-| `RESPANAI_ORG_ID` | Yes | Identifier |
-| `RESPANAI_TENANT_FIELD` | No | Identifier |
-
-## Option 1: let CostGraph pull
-
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS pull**.
-2. Choose **RespanAI** and name the connection.
-3. Enter the billing account these charges belong to, then fill in:
-   - `RESPANAI_API_KEY`
-   - `RESPANAI_ORG_ID`
-   - `RESPANAI_TENANT_FIELD`
+1. Open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **RespanAI**, name the connection, and enter the billing account these
+   charges belong to.
+3. Fill in the values the form asks for. It lists exactly the variables RespanAI
+   needs, marks which are optional, and links this provider's reference for the
+   permissions each one requires.
 4. Select **Connect**.
 
-CostGraph runs a short verification fetch before saving, so a wrong value or a
-missing permission fails immediately rather than silently at the next sync.
+CostGraph verifies the credentials with a short fetch before saving, so a wrong
+value or a missing permission fails while you are still on the form.
 
 <Note>
 Credentials are encrypted at rest and used only to read billing data. Revoke them in
 RespanAI at any time and the connection stops; nothing else is affected.
 </Note>
 
-## Option 2: push it yourself
+## Push it yourself
 
-1. In CostGraph, open **Settings -> Integrations** and pick **FOCUS push**.
+1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with your own credentials:
-
-```bash
-export RESPANAI_API_KEY=...
-export RESPANAI_ORG_ID=...
-export RESPANAI_TENANT_FIELD=...
-
-focus-exporter --provider respanai --month 2026-07 --format json
-```
-
-5. Send the output to CostGraph, quoting the connection id and API key.
-
-Every environment variable and the full FOCUS field mapping are documented in the
-[RespanAI exporter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/respanai.md).
+4. Run the exporter with `--provider respanai`, following the
+   [RespanAI reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/respanai.md) for the environment it needs.
+5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it
 

--- a/docs.json
+++ b/docs.json
@@ -64,9 +64,16 @@
             "group": "Integrations",
             "icon": "plug",
             "pages": [
-              "costgraph/integrations/planetscale",
+              "costgraph/integrations/anthropic",
+              "costgraph/integrations/aws",
+              "costgraph/integrations/confluent",
               "costgraph/integrations/gcp",
-              "costgraph/integrations/aws"
+              "costgraph/integrations/helicone",
+              "costgraph/integrations/modal",
+              "costgraph/integrations/openai",
+              "costgraph/integrations/openrouter",
+              "costgraph/integrations/planetscale",
+              "costgraph/integrations/respanai"
             ]
           }
         ]


### PR DESCRIPTION
Stacked on #43, so this adds the seven remaining providers on top of the GCP and AWS guides.

Only PlanetScale had an integration page, so anthropic, confluent, helicone, modal, openai, openrouter, and respanai had nowhere to send a customer - and the product now links out to per-provider docs from the connect dialog.

## Each page covers both routes

- **CostGraph pulls it** - supply read-only credentials, we call the provider daily.
- **You push it** - run focus-exporter yourself, credentials never leave your side.

Plus what CostGraph does with the records once they land.

## Deliberately thin

These pages do **not** restate variable tables, scopes, API endpoints, or FOCUS field mappings. All of that lives in each provider's exporter reference, next to the code that reads it, and every page links there prominently. Copying it here would create a second source of truth that goes stale the first time an adapter changes - and the catalog already feeds the connect form, so the product asks for the right values without this repo knowing them.

What is here is only what belongs to the product: choosing push versus pull, the connect steps, the verification fetch, and the credential-custody note.

RespanAI carries its "formerly KeywordsAI" line so the rename does not read as an unfamiliar vendor.

Nav lists all ten integration pages alphabetically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added setup and usage guides for Anthropic, Confluent Cloud, Helicone, Modal, OpenAI, OpenRouter, Planetscale, and RespanAI integrations.
  * Documented pull and push ingestion options, credentials, permissions, verification, exporting, and cost reporting.
* **Navigation**
  * Updated the integrations directory to include the newly documented services while retaining existing cloud integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->