### PR TITLE
Add the GitHub integration guide

### DIFF
--- a/costgraph/integrations/github.mdx
+++ b/costgraph/integrations/github.mdx
@@ -1,0 +1,60 @@
+---
+title: GitHub
+description: "Bring GitHub billing usage into CostGraph, pulled by us or pushed by you"
+---
+
+GitHub bills Actions minutes, Packages storage, Copilot seats and more against one
+organization, so a single connection captures the lot.
+
+CostGraph reads GitHub as **FOCUS 1.2** records at a grain of day x product x SKU x
+repository, carrying both gross and net billed cost.
+
+<Card title="GitHub reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/github.md">
+  The credentials and permissions GitHub needs, every environment variable, the API
+  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
+  never drifts from the code.
+</Card>
+
+## Choose how the data reaches us
+
+<CardGroup cols={2}>
+  <Card title="CostGraph pulls it" icon="cloud-arrow-down">
+    You supply a read-only token and we call GitHub once a day. Nothing to run.
+  </Card>
+  <Card title="You push it" icon="cloud-arrow-up">
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
+    Credentials never leave your infrastructure.
+  </Card>
+</CardGroup>
+
+## Let CostGraph pull
+
+1. Open **Settings -> Integrations** and pick **GitHub**.
+2. Name the connection and enter the organization login whose billing you want.
+3. Supply a token with read access to the organization's billing. A fine-grained
+   personal access token needs **Administration: read**; a classic token needs the
+   billing read scope.
+4. Select **Connect**.
+
+CostGraph verifies the token with a short fetch before saving, so a wrong value or a
+missing permission fails while you are still on the form.
+
+<Note>
+Credentials are encrypted at rest and used only to read billing data. Revoke the token
+in GitHub at any time and the connection stops; nothing else is affected.
+</Note>
+
+## Push it yourself
+
+1. Open **Settings -> Integrations** and pick **FOCUS push**.
+2. Create the connection and copy its **Connection ID**.
+3. Create a CostGraph API key with the `focus:write` scope.
+4. Run the exporter with `--provider github`, following the
+   [GitHub reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/github.md) for the environment it needs.
+5. Send the records to CostGraph, quoting the connection id and API key.
+
+## What CostGraph does with it
+
+Records land as raw billing rows, are normalised into line items, and roll up into
+daily cost. From there GitHub spend appears in Cost Overview and in anomaly detection
+alongside every other provider.

--- a/docs.json
+++ b/docs.json
@@ -68,6 +68,7 @@
               "costgraph/integrations/aws",
               "costgraph/integrations/confluent",
               "costgraph/integrations/gcp",
+              "costgraph/integrations/github",
               "costgraph/integrations/helicone",
               "costgraph/integrations/modal",
               "costgraph/integrations/openai",


### PR DESCRIPTION
GitHub is live in the catalog but was the only provider whose Setup guide pointed at a GitHub markdown file rather than docs.costgraph.ai.

Same thin-page pattern as the other ten: what the connection covers, how to choose pull or push, and a card linking the exporter reference for credentials, env vars, endpoints and the FOCUS mapping - so the detail stays next to the code and cannot drift.