### PR TITLE
docs: FOCUS Exporter provider setup guides

### DIFF
--- a/costgraph/focus-exporter/anthropic.mdx
+++ b/costgraph/focus-exporter/anthropic.mdx
@@ -1,0 +1,141 @@
+---
+title: Anthropic
+description: "Exports one FOCUS 1.2 record per (day, model, token bucket) from the Anthropic Admin API, joining the Cost report (real billed cost) with the Messages usage..."
+---
+
+Exports one FOCUS 1.2 record per **(day, model, token bucket)** from the
+Anthropic Admin API, joining the [Cost report](https://platform.claude.com/docs/en/api/admin-api/usage-cost/get-cost-report)
+(real billed cost) with the [Messages usage report](https://platform.claude.com/docs/en/api/admin-api/usage-cost/get-messages-usage-report)
+(token counts). Cost is the real invoiced amount, not an estimate.
+
+Provider name (for `--provider`): `anthropic`
+
+## Environment variables
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `ANTHROPIC_ADMIN_KEY` | yes | An Admin API key (`sk-ant-admin...`). Only an organization admin can create one. Treat it as a credential; never commit it. |
+| `ANTHROPIC_ORG_ID` | no | Overrides `BillingAccountId`. Normally the org id and name are resolved automatically from `GET /v1/organizations/me`; set this only to force a different value. |
+| `ANTHROPIC_TENANT_GROUP` | no | Set to `workspace_id` to split spend per workspace into the FOCUS sub-account columns (adds `workspace_id` to the usage and cost report `group_by`). Any other value is rejected. See [tenancy.md](../tenancy.md). |
+
+The key is sent as the `x-api-key` header, with `anthropic-version: 2023-06-01`.
+
+## Credential setup
+
+Admin API keys are created in the Anthropic Console under **Settings ->
+Admin keys** by an organization admin. They are distinct from regular API keys
+and grant read access to organization-wide usage and cost.
+
+This adapter supports **Claude Console** organizations, which expose the Usage
+and Cost Admin API. Claude Enterprise (claude.ai) organizations are **not**
+supported: they use the separate Analytics API and an Analytics API key, and an
+admin key will not authenticate against those endpoints.
+
+```bash
+export ANTHROPIC_ADMIN_KEY=sk-ant-admin...
+```
+
+## API endpoints used
+
+Base URL: `https://api.anthropic.com`
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /v1/organizations/me` | Organization id and name, for `BillingAccountId` / `BillingAccountName`. |
+| `GET /v1/organizations/cost_report` | Billed cost per day, grouped by `description` (carries `model`, `token_type`, `amount`, `service_tier`, `context_window`). |
+| `GET /v1/organizations/usage_report/messages` | Token counts per day, grouped by `model`. |
+
+Both use `bucket_width=1d`, are bounded by `starting_at`/`ending_at`, and are
+followed to completion via `has_more` / `next_page`.
+
+## FOCUS mapping
+
+Cost `amount` is a decimal string in **lowest currency units (cents)**; it is
+divided by 100 into major units. `token_type` maps to a FOCUS token bucket, and
+the two cache-creation token types are summed into one `cache_creation` bucket:
+
+| Anthropic `token_type` | FOCUS bucket (`SkuMeter`) |
+| --- | --- |
+| `uncached_input_tokens` | `input` |
+| `output_tokens` | `output` |
+| `cache_read_input_tokens` | `cache_read` |
+| `cache_creation.ephemeral_1h_input_tokens` + `cache_creation.ephemeral_5m_input_tokens` | `cache_creation` (summed) |
+
+| FOCUS column | Source |
+| --- | --- |
+| `BilledCost`, `EffectiveCost`, `ListCost` | cost-report `amount` / 100 |
+| `BillingCurrency` | `USD` |
+| `ChargePeriodStart` / `ChargePeriodEnd` | the day bucket `[start, start+24h)` |
+| `ConsumedQuantity` / `ConsumedUnit` | usage-report token count for that (model, bucket) / `tokens` |
+| `ServiceName`, `SkuId` | model (e.g. `claude-opus-4-6`) |
+| `Provider` | `Anthropic` |
+| `ServiceCategory` / `ServiceSubcategory` | `AI and Machine Learning` / `Generative AI` |
+| `ResourceType` | `Model` |
+| `SkuMeter` | token bucket |
+| `SkuPriceId` | `model\|bucket` |
+| `SkuPriceDetails` | JSON of `token_type` / `service_tier` / `context_window` |
+| `ContractedCost` | same as `EffectiveCost` (no separate negotiated rate) |
+| `Publisher`, `InvoiceIssuer` | `Anthropic` |
+| `ChargeFrequency` | `Usage-Based` |
+| `PricingCategory`, `PricingCurrency` | `Standard`, `USD` |
+| `PricingQuantity` / `PricingUnit` | tokens / 1e6, `1M tokens` |
+| `ListUnitPrice` / `ContractedUnitPrice` | cost / (tokens / 1e6), the per-MTok rate |
+| `BillingAccountId` / `BillingAccountName` | org id / name from `GET /v1/organizations/me` (override the id with `ANTHROPIC_ORG_ID`) |
+| `SubAccountId` / `SubAccountName` / `SubAccountType` | each result's `workspace_id` (only when `ANTHROPIC_TENANT_GROUP=workspace_id`) |
+| `x_TokenType` | token bucket |
+| `x_ServiceTier` / `x_ContextWindow` | cost-row dimensions, when present |
+
+## Example
+
+```bash
+export ANTHROPIC_ADMIN_KEY=sk-ant-admin...
+focus-exporter --provider anthropic --start 2025-08-01 --end 2025-08-31 --format json
+```
+
+Representative record:
+
+```json
+{
+  "BilledCost": "3",
+  "EffectiveCost": "3",
+  "ListCost": "3",
+  "BillingCurrency": "USD",
+  "ChargePeriodStart": "2025-08-01T00:00:00Z",
+  "ChargePeriodEnd": "2025-08-02T00:00:00Z",
+  "Provider": "Anthropic",
+  "ServiceName": "claude-opus-4-6",
+  "ServiceCategory": "AI and Machine Learning",
+  "ServiceSubcategory": "Generative AI",
+  "ChargeCategory": "Usage",
+  "ResourceType": "Model",
+  "ConsumedQuantity": "1500",
+  "ConsumedUnit": "tokens",
+  "SkuId": "claude-opus-4-6",
+  "SkuMeter": "input",
+  "SkuPriceId": "claude-opus-4-6|input",
+  "x_TokenType": "input",
+  "x_ServiceTier": "standard",
+  "x_ContextWindow": "0-200k"
+}
+```
+
+## Notes and limitations
+
+- **Granularity is daily.** The cost report only supports `bucket_width=1d`, so
+  `ChargePeriod` is a calendar day.
+- **A window is required.** Unlike PlanetScale, the Anthropic API requires an
+  explicit `starting_at`; always pass `--start`/`--end` (or `--month`).
+- **Cost is rolled up per (model, token bucket) per day.** When a model's cost
+  splits across service tiers or context windows within a day, the amounts are
+  summed and one representative tier/context window is reported in the
+  extensions.
+- **Non-token costs** (web search, code execution, session usage) are surfaced
+  as their own records keyed by `cost_type`, with the provider's description and
+  no token quantity.
+- **Cost without matching usage** (or usage without cost) is still emitted, not
+  dropped. In particular, Priority Tier (`service_tier=priority`) usage is
+  reported by the usage API but **not** by the cost API, so those records are
+  emitted with `BilledCost` unset. An unset cost is not a zero-cost result.
+- **`inference_geo` is not emitted.** The cost report cannot group by it and the
+  usage report is grouped by model, so the API returns it as null; the column is
+  omitted rather than always-empty.

--- a/costgraph/focus-exporter/cloudflare.mdx
+++ b/costgraph/focus-exporter/cloudflare.mdx
@@ -1,0 +1,113 @@
+---
+title: Cloudflare
+description: "Exports FOCUS 1.2 records from Cloudflare's Billable Usage API. One record per billable line item (service x charge period). Cloudflare returns billed..."
+---
+
+Exports FOCUS 1.2 records from Cloudflare's **Billable Usage API**. One record per
+billable line item (service x charge period). Cloudflare returns billed dollars
+per service already, and its field names are FOCUS-native, so the mapping is
+almost one-to-one.
+
+Provider name (for `--provider`): `cloudflare`
+
+## Why this adapter
+
+Cloudflare cost was historically hard to pull - the GraphQL Analytics API returns
+usage only and is explicitly not billing-accurate. Cloudflare's newer **Billable
+Usage API** returns actual **billed dollars** (`BilledCost`, `EffectiveCost`,
+`ListCost`, `ContractedCost`) per service per day, and shapes its field names
+directly on FOCUS columns (including `ChargeCategory` and `ChargeDescription`). So
+this is a clean invoice-cost adapter with no rate card to maintain - and it does
+not depend on any third-party (e.g. Vantage's invoice-upload converter).
+
+## Environment variables
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `CLOUDFLARE_API_TOKEN` | yes | Cloudflare API token with the **Billing Read** permission (account scope). Sent as `Authorization: Bearer <token>`. |
+| `CLOUDFLARE_ACCOUNT_ID` | yes | Cloudflare account id whose billable usage is exported (the `{account_id}` in `/accounts/{account_id}`). |
+
+## API endpoints used
+
+Base URL: `https://api.cloudflare.com`
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /client/v4/accounts/{account_id}/billable-usage?from=&to=` | Billed usage line items for the window (`from`/`to` are `YYYY-MM-DD`). Each item carries FOCUS-shaped fields: `BilledCost`/`EffectiveCost`/`ListCost`/`ContractedCost`, `BillingCurrency`, `ChargeCategory`, `ChargeDescription`, `ChargePeriodStart`/`End`, `ServiceName`, `ServiceFamilyName`, `ConsumedQuantity`/`ConsumedUnit`, `PricingQuantity`/`PricingUnit`, `BillingAccountId`/`BillingAccountName`. |
+
+The requested `--start`/`--end` window is passed as `from`/`to`. Cloudflare's `to`
+is an exclusive upper bound (it returns charge periods whose end falls on or
+before `to`), so the exporter passes `--end` through unchanged to capture the
+window's last day. Cloudflare filters server-side. Charge periods are **daily**
+and data is updated daily.
+
+## FOCUS mapping
+
+| FOCUS column | Source |
+| --- | --- |
+| `BilledCost`, `EffectiveCost` | `BilledCost` |
+| `ListCost` | `ListCost` |
+| `ContractedCost` | `ContractedCost` |
+| `BillingCurrency` | `BillingCurrency` (USD) |
+| `ChargePeriodStart` / `ChargePeriodEnd` | `ChargePeriodStart` / `ChargePeriodEnd` (daily) |
+| `ChargeCategory` | `ChargeCategory` (the API's own value: `Usage`, `Tax`, `Credit`, ...) |
+| `ChargeFrequency` | `Usage-Based` |
+| `PricingCategory` | `Standard` |
+| `ChargeDescription` | `ChargeDescription` |
+| `Provider`, `Publisher`, `InvoiceIssuer` | `Cloudflare` |
+| `ServiceName` | `ServiceName` (e.g. `R2 Storage`, `Workers Paid Requests`) |
+| `ServiceCategory` | mapped from `ServiceFamilyName` (Workers/Durable Objects -> Compute, R2 -> Storage, D1/Workers KV -> Databases, Workers AI -> AI and Machine Learning, Calls/Load Balancing -> Networking, Stream -> Media, Zero Trust -> Security, ...); unrecognized -> `Other` |
+| `BillingAccountId` / `BillingAccountName` | `BillingAccountId` / `BillingAccountName` (falls back to `CLOUDFLARE_ACCOUNT_ID`) |
+| `ConsumedQuantity` / `ConsumedUnit` | `ConsumedQuantity` / `ConsumedUnit` |
+| `PricingQuantity` / `PricingUnit` | `PricingQuantity` / `PricingUnit` |
+| `SkuId`, `SkuMeter` | `ServiceName`, `ServiceFamilyName` |
+
+## Example
+
+```bash
+export CLOUDFLARE_API_TOKEN=...
+export CLOUDFLARE_ACCOUNT_ID=...
+
+focus-exporter --provider cloudflare --month 2026-07 --format json
+```
+
+Representative record (a Workers charge with a list-vs-billed discount):
+
+```json
+{
+  "BilledCost": "12.5",
+  "EffectiveCost": "12.5",
+  "ListCost": "15",
+  "ContractedCost": "12.5",
+  "BillingCurrency": "USD",
+  "ChargePeriodStart": "2026-07-25T00:00:00Z",
+  "ChargePeriodEnd": "2026-07-26T00:00:00Z",
+  "Provider": "Cloudflare",
+  "ServiceName": "Workers Paid Requests",
+  "ServiceCategory": "Compute",
+  "ChargeCategory": "Usage",
+  "ChargeDescription": "Workers Paid usage measured in requests",
+  "ConsumedQuantity": "1500000",
+  "ConsumedUnit": "requests",
+  "SkuId": "Workers Paid Requests",
+  "SkuMeter": "Workers",
+  "BillingAccountId": "acct-9",
+  "BillingAccountName": "Revyl"
+}
+```
+
+## Notes and limitations
+
+- **Grain is account x service x day.** The Billable Usage API has no resource or
+  zone dimension - line items are per service (and service family), per day, for
+  the whole account. There is no per-resource `SubAccount` attribution to emit.
+- **Coverage is the usage-based self-serve catalog** (Workers, Durable Objects,
+  R2, D1, Workers KV, Calls, Workers AI, Vectorize, Images, Stream, ...).
+  Enterprise/contract line items may be billed outside this API.
+- **Not yet full-FOCUS-conformant.** Cloudflare states the fields map to FOCUS
+  columns but does not yet claim full conformance; this adapter maps the returned
+  fields into a conformant record and validates every one.
+- Verified live against a real account (258 line items over ~6 weeks, 0
+  FOCUS-invalid, `BillingAccountName` and categories populated from the API).
+- A line item with an unparseable `BilledCost` or `ChargePeriodStart` is logged
+  and skipped.

--- a/costgraph/focus-exporter/confluent.mdx
+++ b/costgraph/focus-exporter/confluent.mdx
@@ -1,0 +1,83 @@
+---
+title: Confluent Cloud
+description: "Exports one FOCUS 1.2 record per cost line item from the Confluent Cloud Billing API (GET /billing/v1/costs). Cost is the real billed amount (dollars, after..."
+---
+
+Exports one FOCUS 1.2 record per cost line item from the Confluent Cloud
+[Billing API](https://docs.confluent.io/cloud/current/api.html) (`GET
+/billing/v1/costs`). Cost is the real billed `amount` (dollars, after discounts),
+so it maps cleanly onto native FOCUS columns with a real `ResourceId`.
+
+Provider name (for `--provider`): `confluent`
+
+## Environment variables
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `CONFLUENT_CLOUD_API_KEY` | yes | A **Cloud** (org-scoped) API key id - not a cluster/resource key. |
+| `CONFLUENT_CLOUD_API_SECRET` | yes | The Cloud API key secret. Treat as a credential; never commit it. |
+| `CONFLUENT_ORG_ID` | yes | Sets `BillingAccountId` (mandatory FOCUS column; the billing API doesn't return the org id). |
+
+The key/secret are sent as HTTP Basic auth (`Authorization: Basic
+base64(key:secret)`), with the key id as the username.
+
+## Credential setup
+
+Create a **Cloud API key** (Administrative -> not tied to a cluster) with an
+org-level billing role (OrganizationAdmin or BillingAdmin):
+
+```bash
+confluent api-key create --resource cloud
+export CONFLUENT_CLOUD_API_KEY=...
+export CONFLUENT_CLOUD_API_SECRET=...
+```
+
+A resource-scoped key, or a key without a billing role, returns 403.
+
+## API endpoints used
+
+Base URL: `https://api.confluent.cloud`
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /billing/v1/costs` | Cost line items per day. Requires `start_date` (inclusive) and `end_date` (exclusive), both `YYYY-MM-DD` UTC. |
+
+Paginated by `metadata.next` (a full URL with an embedded `page_token`), followed
+to completion.
+
+## FOCUS mapping
+
+| FOCUS column | Source |
+| --- | --- |
+| `BilledCost` / `EffectiveCost` / `ListCost` / `ContractedCost` | `amount` (final amount after discounts, dollars) |
+| `BillingCurrency` / `PricingCurrency` | `USD` (the API returns no currency field; Confluent bills in USD) |
+| `ChargePeriodStart` / `ChargePeriodEnd` | `start_date` / `end_date` |
+| `ChargeCategory` | `Usage`, or `Credit` for a negative `amount` / `PROMO_CREDIT` line |
+| `ConsumedQuantity` / `ConsumedUnit`, `PricingQuantity` / `PricingUnit` | `quantity` / `unit` |
+| `ListUnitPrice` / `ContractedUnitPrice` | `price` (per-unit dollars) |
+| `ServiceName` | `Confluent Cloud` |
+| `Provider` / `Publisher` / `InvoiceIssuer` | `Confluent` |
+| `ServiceCategory` / `ServiceSubcategory` | `Analytics` / `Streaming Analytics` |
+| `ResourceId` / `ResourceName` / `ResourceType` | `resource.id` / `resource.display_name` / `product` |
+| `SkuId` / `SkuMeter` / `SkuPriceId` | `product` / `line_type` / `product\|line_type` |
+| `x_Environment` | `resource.environment.id` |
+| `x_NetworkAccessType` | `network_access_type` |
+| `x_OriginalAmount` / `x_DiscountAmount` | pre-discount amount / discount, when non-zero |
+
+## Example
+
+```bash
+export CONFLUENT_CLOUD_API_KEY=... CONFLUENT_CLOUD_API_SECRET=...
+focus-exporter --provider confluent --start 2026-07-01 --end 2026-08-01 --format json
+```
+
+## Notes and limitations
+
+- **A window is required.** The API mandates `start_date`/`end_date`, so always
+  pass `--start`/`--end` (or `--month`).
+- **Granularity is daily.**
+- **Currency is assumed USD** - the API returns no currency field.
+- **Some lines have no resource** (e.g. `SUPPORT`, `PROMO_CREDIT`); those are
+  emitted without `ResourceId`.
+- Cost is verified against Confluent's published OpenAPI spec; live verification
+  against a real key is pending.

--- a/costgraph/focus-exporter/digitalocean.mdx
+++ b/costgraph/focus-exporter/digitalocean.mdx
@@ -1,0 +1,131 @@
+---
+title: DigitalOcean
+description: "Exports one FOCUS 1.2 record per invoice line item (product x resource) from the DigitalOcean billing API. Each Droplet, Kubernetes cluster, Space, Volume,..."
+---
+
+Exports one FOCUS 1.2 record per **invoice line item** (product x resource) from
+the DigitalOcean billing API. Each Droplet, Kubernetes cluster, Space, Volume,
+Load Balancer, or Managed Database on the invoice becomes its own per-resource
+charge, and the line item's **project** is carried into the FOCUS
+`SubAccount` columns for per-project cost allocation.
+
+Provider name (for `--provider`): `digitalocean`
+
+## Why this adapter
+
+DigitalOcean gives customers an invoice, a billing API, and threshold spend
+alerts - but no FOCUS export, no rightsizing/savings recommendations, and no
+real project-level cost allocation in the console (tag columns arrived only in
+mid-2026). Third-party FinOps platforms mostly do not ingest DigitalOcean
+natively either; it is typically a "bring your own mapping" custom source. Yet
+the invoice API already carries `project_name` on every line item. This adapter
+turns that into ready-to-use FOCUS: per-resource cost with per-project
+attribution that DigitalOcean's own tooling does not surface.
+
+## Environment variables
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `DIGITALOCEAN_TOKEN` | yes | Personal Access Token with **read** scope. Reads the `/v2/customers/my` billing endpoints. Sent as `Authorization: Bearer <token>`. |
+| `DIGITALOCEAN_ACCOUNT_ID` | no | Explicit billing-account id. When empty the adapter resolves it from `/v2/account` (team UUID/name, else account UUID/email); if that call is not accessible (e.g. a billing-only token) the export fails and asks you to set this, rather than inventing an id. |
+
+## Credential setup
+
+1. In the DigitalOcean console go to **API -> Tokens -> Generate New Token**.
+2. Give it **Read** scope (write is not needed). A full-read classic PAT works;
+   a fine-grained token needs at least `billing:read` (and `account:read` to let
+   the adapter auto-label the billing account).
+3. Export it:
+   ```bash
+   export DIGITALOCEAN_TOKEN=dop_v1_...
+   ```
+
+## API endpoints used
+
+Base URL: `https://api.digitalocean.com`
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /v2/account` | Resolve the billing account id/name (team, else account). Best-effort. |
+| `GET /v2/customers/my/invoices?per_page=&page=` | List invoices (and the current-month `invoice_preview`). Paginated via `links.pages.next`. |
+| `GET /v2/customers/my/invoices/{invoice_uuid}?per_page=&page=` | Per-resource `invoice_items` for one invoice. Paginated. |
+
+Only invoices whose `invoice_period` (month) overlaps the requested
+`--start`/`--end` window are fetched. All monetary and duration fields in the API
+are JSON strings and are parsed as exact decimals.
+
+## FOCUS mapping
+
+| FOCUS column | Source |
+| --- | --- |
+| `BilledCost`, `EffectiveCost`, `ContractedCost` | `amount` (USD) |
+| `BillingCurrency` | `USD` |
+| `ChargePeriodStart` / `ChargePeriodEnd` | the line item's `start_time` / `end_time` |
+| `ChargeCategory` | `Usage`; `Tax` for a `Taxes` line, `Credit` when the amount is negative, `Adjustment` for an adjustment line |
+| `ChargeFrequency` | `Usage-Based` |
+| `PricingCategory` | `Standard` |
+| `ChargeDescription` | `product` (plus `group_description` when present) |
+| `Provider`, `Publisher`, `InvoiceIssuer` | `DigitalOcean` |
+| `ServiceName` | `product` (`Droplets`, `Kubernetes Clusters`, `Spaces Subscription`, ...) |
+| `ServiceCategory` | mapped from `product` - DigitalOcean's fixed product-type vocabulary (`Droplets`/`Kubernetes Clusters` -> Compute, `Spaces Subscription`/`Volumes` -> Storage, `Database Clusters` -> Databases, `Load Balancers`/`Floating IPs` -> Networking); an unrecognized product falls back to `Other` |
+| `BillingAccountId` / `BillingAccountName` | resolved team (or account) from `/v2/account`, or `DIGITALOCEAN_ACCOUNT_ID` |
+| `ResourceId` | `resource_uuid` (falls back to `resource_id`) |
+| `ResourceName` | `group_description` (falls back to the resource id) |
+| `ResourceType` | `product` |
+| `ConsumedQuantity` / `ConsumedUnit` | `duration` / `duration_unit` (e.g. `744` / `Hours`) |
+| `SkuId`, `SkuMeter` | `product` |
+| `SubAccountId` / `SubAccountName` / `SubAccountType` | `project_name` / `project_name` / `Project` |
+| `x_InvoiceUUID` / `x_InvoiceId` / `x_InvoicePeriod` | the parent invoice's `invoice_uuid` / `invoice_id` / `invoice_period` |
+
+## Example
+
+```bash
+export DIGITALOCEAN_TOKEN=dop_v1_...
+
+focus-exporter --provider digitalocean --month 2026-07 --format json
+```
+
+Representative record (a Droplet, attributed to the `web` project):
+
+```json
+{
+  "BilledCost": "24",
+  "EffectiveCost": "24",
+  "ListCost": "24",
+  "BillingCurrency": "USD",
+  "ChargePeriodStart": "2026-07-01T00:00:00Z",
+  "ChargePeriodEnd": "2026-08-01T00:00:00Z",
+  "Provider": "DigitalOcean",
+  "ServiceName": "Droplets",
+  "ServiceCategory": "Compute",
+  "ChargeCategory": "Usage",
+  "ChargeDescription": "Droplets: web-01",
+  "ResourceId": "a1111111-2222-3333-4444-555555555555",
+  "ResourceName": "web-01",
+  "ResourceType": "Droplets",
+  "ConsumedQuantity": "744",
+  "ConsumedUnit": "Hours",
+  "SkuId": "Droplets",
+  "SkuMeter": "Droplets",
+  "SubAccountId": "web",
+  "SubAccountName": "web",
+  "SubAccountType": "Project",
+  "x_InvoiceUUID": "inv-2026-07",
+  "x_InvoicePeriod": "2026-07"
+}
+```
+
+## Notes and limitations
+
+- **Per-project attribution.** `project_name` is optional per line item; when
+  present it fills the FOCUS `SubAccount` columns, so a re-seller `--tenant-map`
+  only overrides rows that carry no project.
+- **Current month.** The in-progress month is exposed as `invoice_preview`; it is
+  exported only once DigitalOcean has assigned it a fetchable `invoice_uuid`.
+- **Reconciliation.** Taxes appear as their own `Taxes` line item (emitted as
+  `ChargeCategory = Tax`), so `sum(BilledCost)` over an invoice's records equals
+  the invoice total exactly - live-verified across several months. A negative
+  line is emitted as a `Credit`.
+- **Currency is USD.** The billing API reports amounts in USD only.
+- A line item with an unparseable amount is logged and skipped; it never aborts
+  the whole export.

--- a/costgraph/focus-exporter/github.mdx
+++ b/costgraph/focus-exporter/github.mdx
@@ -1,0 +1,247 @@
+---
+title: GitHub
+description: "Exports one FOCUS 1.2 record per (day, product, SKU, repository) from the GitHub organization billing usage report. GitHub reports both a gross and a net..."
+---
+
+Exports one FOCUS 1.2 record per **(day, product, SKU, repository)** from the
+GitHub organization billing usage report. GitHub reports both a gross and a net
+amount per line item, so included-quota consumption shows up as a real charge
+(`ListCost`) that was billed at zero (`BilledCost`).
+
+Provider name (for `--provider`): `github`
+
+## Environment variables
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `GITHUB_TOKEN` | yes | Token with read access to the organization's billing. Sent as `Authorization: Bearer <token>`. |
+| `GITHUB_ORG` | yes | Organization login whose billing usage is exported (the `{org}` in `github.com/{org}`). |
+
+## Credential setup
+
+1. Create a token scoped to the organization:
+   - **Fine-grained PAT** (recommended): organization permission
+     **Administration: read**.
+   - **Classic PAT**: the `admin:org` scope (read is sufficient) or the
+     organization's billing read scope.
+2. If the organization enforces SAML SSO, authorize the token for that
+   organization after creating it, otherwise the API returns 403.
+3. Export both variables:
+   ```bash
+   export GITHUB_TOKEN=github_pat_...
+   export GITHUB_ORG=your-org
+   ```
+
+### Minimum permissions
+
+The exporter only reads the billing usage report. No repository content,
+workflow, or write access is required.
+
+## API endpoints used
+
+Base URL: `https://api.github.com`
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /organizations/{org}/settings/billing/usage?year=&month=` | Per-day usage line items: `product`, `sku`, `quantity`, `unitType`, `pricePerUnit`, `grossAmount`, `discountAmount`, `netAmount`, `repositoryName`. |
+
+The endpoint is queried one calendar month at a time - it takes `year` and
+`month`, not an arbitrary range - so the requested `--start`/`--end` window is
+split into months and the returned days are filtered back down to the window.
+The endpoint is not paginated; it returns the whole month in one response.
+
+## FOCUS mapping
+
+| FOCUS column | Source |
+| --- | --- |
+| `BilledCost`, `EffectiveCost`, `ContractedCost` | `netAmount` (what GitHub actually charges after included quota and discounts) |
+| `ListCost` | `grossAmount` (undiscounted list value of the same usage) |
+| `BillingCurrency` | `USD` |
+| `ChargePeriodStart` / `ChargePeriodEnd` | the line item's `date`, and that day plus 24h |
+| `BillingPeriodStart` / `BillingPeriodEnd` | the calendar month containing the charge |
+| `ChargeCategory` | `Usage` |
+| `ChargeFrequency` | `Usage-Based` |
+| `PricingCategory` | `Standard` |
+| `ChargeDescription` | `sku` |
+| `Provider`, `Publisher`, `InvoiceIssuer` | `GitHub` |
+| `ServiceName` | `product` mapped to its product name (`GitHub Actions`, `GitHub Copilot`, ...) |
+| `ServiceCategory` | `Developer Tools` |
+| `BillingAccountId` | `GITHUB_ORG` |
+| `ConsumedQuantity` / `ConsumedUnit` | `quantity` / `unitType` (`Minutes`, `GigabyteHours`, ...) |
+| `ListUnitPrice` | `pricePerUnit` |
+| `ResourceId` / `ResourceName` | `repositoryName` |
+| `ResourceType` | `Repository` |
+| `SkuId`, `SkuMeter` | `sku` |
+| `SkuPriceId` | `product\|sku` |
+| `x_DiscountAmount` | `discountAmount`, emitted only when non-zero |
+| `x_RunnerClass` / `x_RunnerCores` | on Actions compute rows only: the runner OS (`linux`/`macos`/`windows`) and, for larger runners, the core count, parsed from the `sku` - the rightsizing signal (macOS ~10x Linux; larger vs standard) |
+
+## Example
+
+```bash
+export GITHUB_TOKEN=github_pat_...
+export GITHUB_ORG=acme
+
+focus-exporter --provider github --month 2026-08 --format json
+```
+
+Representative record (a run fully covered by the included Actions quota):
+
+```json
+{
+  "BilledCost": "0",
+  "EffectiveCost": "0",
+  "ListCost": "16.584",
+  "ContractedCost": "0",
+  "BillingCurrency": "USD",
+  "ChargePeriodStart": "2026-08-05T00:00:00Z",
+  "ChargePeriodEnd": "2026-08-06T00:00:00Z",
+  "Provider": "GitHub",
+  "ServiceName": "GitHub Actions",
+  "ServiceCategory": "Developer Tools",
+  "ChargeCategory": "Usage",
+  "ChargeDescription": "Actions Linux",
+  "ResourceId": "repo-ci",
+  "ResourceName": "repo-ci",
+  "ResourceType": "Repository",
+  "ConsumedQuantity": "2764",
+  "ConsumedUnit": "Minutes",
+  "ListUnitPrice": "0.006",
+  "SkuId": "Actions Linux",
+  "SkuMeter": "Actions Linux",
+  "SkuPriceId": "Actions|Actions Linux",
+  "x_DiscountAmount": "16.584"
+}
+```
+
+## Metered vs subscription (reconciliation boundary)
+
+GitHub has two billing rails, and it is migrating everything onto the second:
+
+- **Metered / usage-based** - Actions, Packages, Codespaces, Git LFS, and all of
+  Copilot (AI credits, premium requests, agents, **and Copilot Business/Enterprise
+  seats billed as `UserMonths`**). This is the usage report above, and on an
+  account whose licenses are already usage-based it is the **entire** bill.
+- **Volume / subscription** - the fixed base plan (Team, Enterprise) on
+  traditional annual billing. This is a per-seat subscription that the usage
+  report does **not** contain.
+
+To reconcile volume-billed accounts, the adapter reconstructs the base plan: it
+reads `GET /orgs/{org}` (`plan.name`, `plan.filled_seats`) and prices it with a
+static per-seat rate card:
+
+| Plan | Per-seat / month |
+| --- | --- |
+| `free` | $0 (no record) |
+| `team` | $4 |
+| `enterprise` | $21 |
+
+It emits one record per month in the window: `ChargeCategory = Purchase`,
+`ChargeFrequency = Recurring`, `PricingCategory = Committed`,
+`ConsumedQuantity = filled_seats`, `ConsumedUnit = UserMonths`, cost =
+`filled_seats x rate`. `ServiceName` is e.g. `GitHub Team plan`.
+
+Caveats, by design:
+- **Skipped when the plan is already metered.** If the usage report already
+  contains a line for the base plan (usage-based accounts), the reconstruction is
+  suppressed so the plan is not double-counted.
+- **Current seat count.** `filled_seats` is the current value, applied to each
+  month in the window - an approximation for past months if the seat count
+  changed.
+- **Static rate card.** The per-seat prices are hard-coded (GitHub does not expose
+  plan pricing via API); update them if GitHub's list prices change.
+- **Advanced Security on volume billing and Marketplace subscriptions are not
+  yet reconstructed** - a follow-up. On usage-based accounts they appear in the
+  usage report and are already captured.
+
+So `sum(BilledCost)` is exact on usage-based accounts, and on volume accounts it
+is the metered usage plus the reconstructed base-plan subscription.
+
+## Per-user Copilot seats
+
+The usage report bills Copilot seats as one aggregate `Copilot Business |
+UserMonths` line - a lump with no user attribution. For the **current** billing
+month, the adapter instead expands that into **one FOCUS row per seat-holder**,
+so each seat is a resource that can be charged back and rightsized. It reads
+`GET /orgs/{org}/copilot/billing/seats` (the live roster: `assignee.login`,
+`last_activity_at`, `last_activity_editor`, `last_authenticated_at`,
+`created_at`) and emits, per seat:
+
+| FOCUS field | Value |
+| --- | --- |
+| `ResourceType` | `Copilot Seat` |
+| `ResourceId` / `ResourceName` | the user's `login` |
+| `BilledCost` | the month's Copilot cost / seat count (even split) |
+| `ConsumedQuantity` / `ConsumedUnit` | `UserMonths / seat count` / `UserMonths` |
+| `ChargeCategory` / `ChargeFrequency` / `PricingCategory` | `Purchase` / `Recurring` / `Committed` |
+| `x_LastActivityAt`, `x_LastActivityEditor`, `x_LastAuthenticatedAt`, `x_SeatCreatedAt` | per-seat activity signals (absent when never used) |
+
+The per-seat rows **replace** the current-month aggregate line, so
+`sum(BilledCost)` still equals it. A consumer can then flag an idle seat
+(`x_LastActivityAt` absent or stale) directly - reclaimable cost is that row's
+`BilledCost` - and attribute cost per user.
+
+Two constraints, by design:
+- **Even allocation.** GitHub does not attribute Copilot cost per user, so the
+  month's cost is split evenly across the live roster. It reconciles to the
+  billed aggregate but is not a per-user *billed* amount.
+- **Current month only.** `billing/seats` is a live snapshot (no historical
+  roster), so only the current month is expanded; past months keep the aggregate
+  `UserMonths` line. If the roster can't be read or is empty, the aggregate line
+  is emitted unchanged.
+
+## Notes and limitations
+
+- **Granularity is daily.** The usage report has no finer grain than a day, so
+  `ChargePeriod` is always a single UTC day.
+- **Currency is USD.** The usage report reports amounts in USD only.
+- **Repository is optional.** Org-level line items (for example Copilot
+  credits) carry an empty `repositoryName`, and their `ResourceId` is omitted.
+- A line item with an unparseable date or an unusable `netAmount` is logged and
+  skipped; it never aborts the whole export.
+
+## Per-resource utilization roadmap (follow-ups)
+
+Per-user Copilot seats are the first of a family: emit the **finest resource
+grain the API allows plus a utilization/activity overlay as `x_` extensions**, so
+a consumer can pair cost with utilization for rightsizing and waste analysis.
+Each is gated on the underlying billing/activity data being available. Ranked by
+leverage:
+
+1. **Actions rightsizing** (largest metered bill). *Runner rightsizing is done*:
+   Actions compute rows carry `x_RunnerClass` (linux/macos/windows) and
+   `x_RunnerCores`, parsed from the `sku` - no extra API - flagging runs that
+   could move macOS/Windows/large -> Linux/standard. *Remaining follow-up*:
+   failed/redundant-run waste (`x_FailedMinutesShare` / `x_RedundantMinutesShare`,
+   share of a repo's minutes spent on failed or superseded runs), which needs the
+   Actions Runs API.
+2. **Copilot premium requests per user** - one row per user (like seats) with
+   `x_PremiumRequests` from the Copilot metrics API, for per-user chargeback.
+   Reuses the seat expansion.
+3. **Idle Codespaces** - one row per codespace with `x_LastUsedAt` / `x_State`
+   (storage bills even when stopped) from `/orgs/{org}/codespaces`.
+4. **Stale Packages / artifacts** - per-version rows with `x_LastDownloadedAt` /
+   `x_ArtifactExpired` so never-downloaded storage can be identified.
+5. **GHAS committers** - one row per active committer with `x_LastCommitAt` to
+   surface idle committer seats.
+
+### Live vs settled
+
+These overlays come from **current-state** endpoints (the seat roster, Actions
+runs, codespaces, package downloads) with no billing lag, so the utilization
+signal is available in real time even though billed cost is not. That is a
+natural split:
+
+- **Settled** (the billing usage report): authoritative, discounted `BilledCost`,
+  but lagged ~a day and aggregated monthly.
+- **Live**: the current state and overlay can be read on any cadence; where the
+  settled report has no line yet, cost can only be a **list-rate estimate**, which
+  should stay clearly marked as an estimate rather than a settled `BilledCost`.
+
+So the utilization signal never waits on billing latency; only exact billed cost
+does. Caveat: the live view is a current snapshot only (no historical backfill),
+and a fully-live Actions cost means aggregating the runs yourself rather than
+letting the report pre-aggregate.
+
+Also still open: Advanced Security on volume billing and Marketplace
+subscriptions are not yet reconstructed (see the reconciliation boundary above).

--- a/costgraph/focus-exporter/grafanacloud.mdx
+++ b/costgraph/focus-exporter/grafanacloud.mdx
@@ -1,0 +1,114 @@
+---
+title: Grafana Cloud
+description: "Exports FOCUS 1.2 records from the Grafana Cloud billed-usage API. Each billed dimension (Metrics, Logs, Traces, Grafana Users, ...) is emitted per stack,..."
+---
+
+Exports FOCUS 1.2 records from the Grafana Cloud **billed-usage** API. Each billed
+dimension (Metrics, Logs, Traces, Grafana Users, ...) is emitted per **stack**,
+using the per-stack cost (`attributedCost`) Grafana returns, so each stack is a
+resource that can be charged back.
+
+Provider name (for `--provider`): `grafanacloud`
+
+## Why this adapter
+
+Grafana Cloud's billed-usage API returns dollars per dimension **and per stack**
+(`attributedCost`), with the applied rate card, so there is no pricing to
+reconstruct and no allocation to guess - the adapter maps Grafana's own per-stack
+cost into FOCUS, with the stack in the `SubAccount` columns for chargeback.
+(Grafana also ships a native FOCUS export; this adapter is the same data in one
+pipeline with the rest of your providers, keyed to per-stack `SubAccount`.)
+
+## Environment variables
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `GRAFANA_CLOUD_TOKEN` | yes | Grafana Cloud **Access Policy token** (`glc_...`) whose policy realm is the org and which carries billing read scopes (e.g. `billing-metrics:read`, `org-billing-info:read`, `org-billing-rate:read`, `invoices:read`, `orgs:read`). A stack **service-account** token (`glsa_...`) does not work - the billed-usage endpoint is on grafana.com, not the stack. Sent as `Authorization: Bearer <token>`. |
+| `GRAFANA_CLOUD_ORG` | yes | Grafana Cloud organization slug (the `{org}` in `grafana.com/orgs/{org}`). |
+
+## API endpoints used
+
+Base URL: `https://grafana.com/api`
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /orgs/{org}/billed-usage?year=&month=` | Billed dimensions for one calendar month. Returns `{ "items": [ ... ] }`; each item has `dimensionName`, `unit`, `amountDue` (USD), `overage`, and a per-stack `usages[]` breakdown (`stackId`, `stackName`, `totalUsage`, `attributedCost`, `isProrated`). |
+
+The endpoint takes only `year` and `month` (no pagination params) and returns
+every dimension in one response, so the requested `--start`/`--end` window is
+split into months and each month is fetched once.
+
+## FOCUS mapping
+
+| FOCUS column | Source |
+| --- | --- |
+| `BilledCost`, `EffectiveCost`, `ListCost` | the stack's `attributedCost` (for a dimension with no stack breakdown, the dimension `amountDue`) |
+| `BillingCurrency` | `USD` |
+| `ChargePeriodStart` / `ChargePeriodEnd` | the dimension's `periodStart` / `periodEnd` |
+| `ChargeCategory` | `Usage` (`Credit` when the amount is negative) |
+| `ChargeFrequency` | `Usage-Based` |
+| `PricingCategory` | `Standard` |
+| `Provider`, `Publisher`, `InvoiceIssuer` | `Grafana Cloud` |
+| `ServiceName` | `Grafana Cloud <dimensionName>` (e.g. `Grafana Cloud Metrics`) |
+| `ServiceCategory` | `Management and Governance` (observability) |
+| `BillingAccountId` / `BillingAccountName` | `GRAFANA_CLOUD_ORG` |
+| `ConsumedQuantity` / `ConsumedUnit` | the stack's `totalUsage` / the dimension `unit` |
+| `ResourceId` / `ResourceName` | `stackId` / `stackName` |
+| `ResourceType` | `Grafana Stack` |
+| `SubAccountId` / `SubAccountName` / `SubAccountType` | `stackName` / `stackName` / `Stack` |
+| `SkuId`, `SkuMeter` | `dimensionId` |
+| `x_Overage` | the dimension's billed `overage`, when non-zero |
+| `x_IsProrated` / `x_StackLabels` | per-stack flags when present |
+
+A dimension with no per-stack breakdown (org-level dimensions) is emitted as a
+single row with `amountDue`.
+
+## Example
+
+```bash
+export GRAFANA_CLOUD_TOKEN=glc_...
+export GRAFANA_CLOUD_ORG=acme
+
+focus-exporter --provider grafanacloud --month 2026-07 --format json
+```
+
+Representative record (a stack's Metrics cost from `attributedCost`):
+
+```json
+{
+  "BilledCost": "86.67",
+  "EffectiveCost": "86.67",
+  "ListCost": "86.67",
+  "BillingCurrency": "USD",
+  "ChargePeriodStart": "2026-07-01T00:00:00Z",
+  "ChargePeriodEnd": "2026-07-31T23:59:59Z",
+  "Provider": "Grafana Cloud",
+  "ServiceName": "Grafana Cloud Metrics",
+  "ServiceCategory": "Management and Governance",
+  "ChargeCategory": "Usage",
+  "ChargeDescription": "Metrics active series",
+  "ResourceId": "111",
+  "ResourceName": "prod",
+  "ResourceType": "Grafana Stack",
+  "ConsumedQuantity": "20000",
+  "ConsumedUnit": "series",
+  "SkuId": "metrics",
+  "SubAccountId": "prod",
+  "SubAccountName": "prod",
+  "SubAccountType": "Stack",
+  "x_Overage": "20000"
+}
+```
+
+## Notes and limitations
+
+- **Per-stack cost is Grafana's own** (`attributedCost`), not an allocation, so
+  `sum(BilledCost)` equals the invoice exactly.
+- **Granularity is monthly.** The billed-usage endpoint reports one calendar month
+  at a time.
+- **Currency.** The endpoint reports the org's billed amount; this adapter labels
+  it `USD` (Grafana Cloud's default). Verify for non-USD-billed orgs.
+- Verified live against a real org (5 dimensions, `sum(BilledCost)` matching the
+  month's invoice to the cent, 0 FOCUS-invalid, per-stack attribution populated).
+- A stack line with an unparseable `attributedCost` (or an org-level dimension
+  with an unparseable `amountDue`) is logged and skipped.

--- a/costgraph/focus-exporter/helicone.mdx
+++ b/costgraph/focus-exporter/helicone.mdx
@@ -1,0 +1,76 @@
+---
+title: Helicone
+description: "Exports FOCUS 1.2 records from the Helicone request-query API. Helicone is an LLM gateway/observability proxy, so one integration captures spend across..."
+---
+
+Exports FOCUS 1.2 records from the Helicone request-query API. Helicone is an
+LLM gateway/observability proxy, so one integration captures spend across every
+model and upstream provider you route through it. One record per
+**(day, model, upstream provider)**, aggregated from per-request rows.
+
+Provider name (for `--provider`): `helicone`
+
+This adapter uses an HTTP **POST** (the request-query API takes a JSON filter
+body), unlike the GET-based adapters.
+
+## Environment variables
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `HELICONE_API_KEY` | yes | Helicone API key (`sk-helicone-...`), sent as `Authorization: Bearer <key>`. |
+| `HELICONE_ORG_ID` | yes | Populates the mandatory `BillingAccountId` (the query API returns no account id). |
+| `HELICONE_TENANT_PROPERTY` | no | Custom-property name that carries the downstream tenant/customer (e.g. `Tenant`). When set, spend is split per tenant into the FOCUS sub-account columns. See [tenancy.md](../tenancy.md). |
+
+## API endpoints used
+
+Base URL: `https://api.helicone.ai`
+
+| Endpoint | Purpose |
+| --- | --- |
+| `POST /v1/request/query` | Per-request rows over the window. The body carries a `created_at` filter (`gte` start, `lt` end); the adapter pages via `offset`/`limit` and rolls the rows up by (day, model, provider) client-side. Rows outside the window are also dropped client-side as a guard. |
+
+There is no server-side per-model/provider/day aggregation endpoint, so the
+adapter paginates and aggregates locally.
+
+## FOCUS mapping
+
+| FOCUS column | Source |
+| --- | --- |
+| `BilledCost` / `EffectiveCost` / `ListCost` / `ContractedCost` | sum of `costUSD` (falling back to `cost`), in USD |
+| `BillingCurrency` / `PricingCurrency` | `USD` |
+| `ChargePeriodStart` / `ChargePeriodEnd` | the day (from `request_created_at`) |
+| `ConsumedQuantity` / `ConsumedUnit` | `prompt_tokens + completion_tokens` / `tokens` |
+| `ServiceName`, `SkuId`, `ResourceId`/`Name` | `request_model` |
+| `Provider` / `Publisher` / `InvoiceIssuer` | `Helicone` |
+| `ServiceCategory` / `ServiceSubcategory` | `AI and Machine Learning` / `Generative AI` |
+| `SkuMeter` / `SkuPriceId` | `provider` / `request_model\|provider` |
+| `x_UpstreamProvider` | `provider` (e.g. OPENAI, ANTHROPIC) |
+| `x_PromptTokens` / `x_CompletionTokens` | token counts |
+| `BillingAccountId` | `HELICONE_ORG_ID` |
+| `SubAccountId` / `SubAccountName` / `SubAccountType` | the `HELICONE_TENANT_PROPERTY` value on each request (only when that env is set) |
+
+## Example
+
+```bash
+export HELICONE_API_KEY=sk-helicone-...
+export HELICONE_ORG_ID=your-org
+focus-exporter --provider helicone --start 2026-07-01 --end 2026-08-01 --format json
+```
+
+## Notes and limitations
+
+- **A window is required.** Pass `--start`/`--end` or `--month`.
+- **Cost is per (model, provider), not per token bucket.** Each request carries
+  one `costUSD`; the adapter sums it per day/model/provider and does not split
+  input vs output pricing (token counts ride as `x_` extensions).
+- **Gateway/platform fees are not captured (API gap).** Reported `BilledCost` is
+  request spend from the query API; Helicone's own subscription/platform charges
+  are not in it and are not fabricated (see the charge-completeness rule in
+  AGENTS.md).
+- **Per-tenant attribution is opt-in** via `HELICONE_TENANT_PROPERTY`. When set,
+  the rollup grain becomes (day, model, provider, tenant) and each tenant's spend
+  lands in its own `SubAccountId`. Unset, output is unchanged. See
+  [tenancy.md](../tenancy.md).
+- The exact `request/query` filter shape, cost field (`costUSD` vs `cost`), and
+  the per-request property field (`request_properties`) are taken from the
+  documented schema; live verification against a real key is pending.

--- a/costgraph/focus-exporter/modal.mdx
+++ b/costgraph/focus-exporter/modal.mdx
@@ -1,0 +1,104 @@
+---
+title: Modal
+description: "Exports FOCUS 1.2 records from Modal's workspace billing report. Modal is a serverless GPU/compute platform; this adapter captures the per-object, per-day..."
+---
+
+Exports FOCUS 1.2 records from Modal's workspace billing report. Modal is a
+serverless GPU/compute platform; this adapter captures the per-object, per-day
+cost of everything running in a workspace - including self-hosted model
+inference (Moondream, Qwen-VL, and other apps deployed on Modal).
+
+Provider name (for `--provider`): `modal`
+
+Unlike the other adapters, Modal has no REST billing endpoint: the billing data
+is served over **gRPC** (`api.modal.com:443`, service `modal.client.ModalClient`,
+RPC `WorkspaceBillingReport`, server-streaming). This adapter therefore talks
+gRPC directly rather than going through the shared `HTTPGet` seam.
+
+## Environment variables
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `MODAL_TOKEN_ID` | yes | Token id (`modal token new`), sent as gRPC metadata `x-modal-token-id`. |
+| `MODAL_TOKEN_SECRET` | yes | Token secret, sent as gRPC metadata `x-modal-token-secret`. |
+| `MODAL_WORKSPACE_ID` | yes | Populates the mandatory `BillingAccountId`. The workspace itself is implied by the token; this is a stable label for the account. |
+
+## API used
+
+| Transport | Target | Purpose |
+| --- | --- | --- |
+| gRPC (TLS) | `api.modal.com:443` `modal.client.ModalClient/WorkspaceBillingReport` | Per-object, per-interval usage cost. The adapter requests `resolution="d"` (daily) over the `[start, end)` window. |
+| gRPC (TLS) | `api.modal.com:443` `modal.client.ModalClient/WorkspaceBillingSummary` | Month `metered_cost` vs `billed_cost` plus an `adjustments` map, used to emit the non-usage charges so total `BilledCost` reconciles to the invoice. |
+
+## FOCUS mapping
+
+| FOCUS column | Source |
+| --- | --- |
+| `BilledCost` / `EffectiveCost` / `ListCost` / `ContractedCost` | item `cost` (USD) |
+| `BillingCurrency` / `PricingCurrency` | `USD` |
+| `ChargePeriodStart` / `ChargePeriodEnd` | item `interval` (the day) |
+| `BillingPeriodStart` / `BillingPeriodEnd` | calendar month of the interval |
+| `Provider` / `Publisher` / `InvoiceIssuer` | `Modal` |
+| `ServiceName` | `Modal` |
+| `ServiceCategory` | `Compute` |
+| `ResourceId` / `SkuId` | item `object_id` |
+| `ResourceName` / `ChargeDescription` | item `description` |
+| `ResourceType` | derived from the `object_id` prefix (`ap`->App, `fu`->Function, `vo`->Volume, `im`->Image, `sb`->Sandbox) |
+| `SkuPriceDetails` | item `cost_by_resource` (per-resource breakdown, e.g. `GPU:H100`, `CPU`, `Memory`) |
+| `BillingAccountId` | `MODAL_WORKSPACE_ID` |
+| `x_Environment` | item `environment_name` |
+| `x_Tags` | item `tags` |
+
+## Example
+
+```bash
+export MODAL_TOKEN_ID=ak-...
+export MODAL_TOKEN_SECRET=as-...
+export MODAL_WORKSPACE_ID=your-workspace
+focus-exporter --provider modal --start 2026-07-01 --end 2026-08-01 --format json
+```
+
+## Non-usage charges
+
+Beyond per-object usage, the workspace billing summary's `adjustments` map is
+emitted as its own records so the total reconciles to what Modal actually bills:
+
+The adjustment key is matched case-insensitively on a substring, so Modal's
+real keys map cleanly:
+
+| Adjustment key (real) | matched on | `ChargeCategory` | Notes |
+| --- | --- | --- | --- |
+| `Plan Cost` | `plan` | Purchase | platform/plan fee |
+| `Reservation Adjustment` | `reservation` | Purchase | committed-use (`PricingCategory = Committed`) |
+| `Credits` | `credit` | Credit | applied credits (negative) |
+| `Free Storage` | `storage` | Usage | storage charge |
+| anything else | - | Adjustment | forward-compatible catch-all |
+
+Each carries the summary month as its charge period. Amounts are taken from the
+API verbatim (the summary is signed so `metered_cost + sum(adjustments) =
+billed_cost`). The keys, casing, and the `metered_cost_breakdown` /
+`adjustments` shapes are **live-verified** against a real workspace.
+
+## Notes and limitations
+
+- **A window is required** (the report needs a start and end). Pass
+  `--start`/`--end` or `--month`.
+- **Non-usage charges need the monthly summary.** They are keyed to the summary
+  month (`WorkspaceBillingSummary` is monthly), while usage records are daily. If
+  the summary call fails, usage records are still emitted and the non-usage
+  charges are skipped with a log line.
+- **Daily grain.** The adapter requests `resolution="d"`; each record is one
+  object for one day. The per-resource split (CPU / memory / specific GPU types)
+  rides in `SkuPriceDetails`, so GPU spend is visible without losing the object
+  total in `BilledCost`.
+- **The daily report caps at 31 days.** Modal rejects a daily report spanning
+  more than 31 days, so the adapter splits the window into <=30-day chunks and
+  concatenates them - any `--start`/`--end` range works transparently.
+- **The summary start is snapped to the UTC month boundary.** `WorkspaceBillingSummary`
+  requires a first-of-month start; the adapter derives it from the window start,
+  so the non-usage charges always come from the month the window begins in.
+- **Rows with no cost are skipped** rather than emitted as empty-cost records.
+- The gRPC client and the trimmed billing protobuf live under
+  `pkg/integrations/modal/modalpb/` (regenerate with `buf generate` from
+  `billing.proto`; the checked-in `*.pb.go` are the source of truth at build
+  time).

--- a/costgraph/focus-exporter/openai.mdx
+++ b/costgraph/focus-exporter/openai.mdx
@@ -1,0 +1,102 @@
+---
+title: OpenAI
+description: "Exports FOCUS 1.2 records from the OpenAI Costs Admin API."
+---
+
+Exports FOCUS 1.2 records from the OpenAI [Costs Admin API](https://platform.openai.com/docs/api-reference/usage/costs).
+
+OpenAI's cost endpoint returns, per day and per `line_item`, the billed
+`amount`, the billed `quantity` (token count), and the `project_id`. A line item
+is `"<model>, <token-type>"` (e.g. `"gpt-4o-2024-08-06, input"`), so a single
+cost row already carries cost, quantity, model, and token bucket together - no
+cross-endpoint join is needed. Each row becomes one FOCUS charge.
+
+Provider name (for `--provider`): `openai`
+
+## Environment variables
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `OPENAI_ADMIN_KEY` | yes | An Admin API key (`sk-admin-...`) or a key with the `api.usage.read` scope. Only an org owner can create an admin key / grant the scope. |
+| `OPENAI_ORG_ID` | yes | Sets `BillingAccountId` on every record (mandatory FOCUS column; the cost endpoint doesn't return the org id). |
+| `OPENAI_TENANT_GROUP` | no | Set to `project_id` to split spend per project into the FOCUS sub-account columns (adds `project_id` to the cost `group_by`). Any other value is rejected. See [tenancy.md](../tenancy.md). |
+
+The key is sent as `Authorization: Bearer <key>`.
+
+## Credential setup
+
+The Costs endpoint requires the `api.usage.read` scope. Create an **Admin key**
+in the OpenAI dashboard (Settings -> Organization -> Admin keys), or grant an
+existing service-account/API key the **Usage read** role. A regular or
+service-account key without that scope returns `403 Missing scopes:
+api.usage.read`.
+
+```bash
+export OPENAI_ADMIN_KEY=sk-admin-...
+```
+
+## API endpoints used
+
+Base URL: `https://api.openai.com`
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /v1/organization/costs` | Billed cost, quantity, and project per day, grouped by `line_item` (plus `project_id` when tenancy is enabled). |
+
+It takes `start_time` (unix seconds, required) / `end_time`, `bucket_width=1d`,
+and is followed to completion via `has_more` / `next_page`.
+
+## FOCUS mapping
+
+The `line_item` string is split on the last `", "` into a model and a token
+type. Recognised token types map to a bucket:
+
+| `line_item` token type | FOCUS bucket (`SkuMeter`) |
+| --- | --- |
+| `input` | `input` |
+| `cached input` | `cache_read` |
+| `output` | `output` |
+
+A `line_item` that is not `"<model>, <known-token-type>"` (e.g. `"Image
+models"`, `"Web search"`, credits) does not parse to a bucket and falls back to
+a **cost-only** charge keyed on the raw line item.
+
+| FOCUS column | Source |
+| --- | --- |
+| `BilledCost` / `EffectiveCost` / `ListCost` | `amount.value` (dollars) |
+| `BillingCurrency` | `amount.currency`, uppercased (`usd` -> `USD`) |
+| `ConsumedQuantity` / `ConsumedUnit` | `quantity` / `tokens` (parsed token lines only) |
+| `ServiceName`, `ResourceId`, `SkuId` | model (e.g. `gpt-4o-2024-08-06`); the raw `line_item` on a fallback row |
+| `SkuMeter` | token bucket; the raw `line_item` on a fallback row |
+| `SkuPriceId` | `model\|bucket` |
+| `ChargeCategory` | `Usage`, or `Credit` when `amount` is negative |
+| `Provider`, `Publisher`, `InvoiceIssuer` | `OpenAI` |
+| `ServiceCategory` / `ServiceSubcategory` | `AI and Machine Learning` / `Generative AI` |
+| `BillingAccountId` | `OPENAI_ORG_ID` (required) |
+| `SubAccountId` / `SubAccountName` / `SubAccountType` | each row's `project_id` (only when `OPENAI_TENANT_GROUP=project_id`) |
+
+## Example
+
+```bash
+export OPENAI_ADMIN_KEY=sk-admin-...
+focus-exporter --provider openai --start 2026-07-01 --end 2026-08-01 --format json
+```
+
+## Notes and limitations
+
+- **The cost endpoint is the single source of truth.** Its `quantity` per
+  `(model, token-type)` matches the `usage/completions` billed token counts
+  exactly (`input` = uncached input, `cached input` = cache reads, `output` =
+  output), so nothing is fetched from the usage endpoint. Request counts
+  (`num_model_requests`) and text/audio/image sub-splits are the only fields that
+  live solely on `usage/completions`; they are telemetry, not billed quantities,
+  and are not exported.
+- **Fallback rows carry no quantity.** A `line_item` that does not resolve to a
+  known model+token-type (image/audio product lines, web search, credits) is
+  emitted as a cost-only charge - never mis-attributed to a token bucket.
+- **A window is required.** Pass `--start` and `--end` together (or `--month`);
+  the CLI rejects an open-ended export for this provider because the API
+  requires `start_time`.
+- **Granularity is daily** (`bucket_width=1d`).
+- The `line_item` vocabulary (`"<model>, input|cached input|output"`) is verified
+  against a live organization's cost data.

--- a/costgraph/focus-exporter/openrouter.mdx
+++ b/costgraph/focus-exporter/openrouter.mdx
@@ -1,0 +1,93 @@
+---
+title: OpenRouter
+description: "Exports FOCUS 1.2 records from the OpenRouter Activity API (GET /api/v1/activity). OpenRouter is an LLM gateway, so one integration captures spend across..."
+---
+
+Exports FOCUS 1.2 records from the OpenRouter [Activity API](https://openrouter.ai/docs/api/api-reference/analytics/get-user-activity)
+(`GET /api/v1/activity`). OpenRouter is an LLM gateway, so one integration
+captures spend across **every model and upstream provider** you route through it.
+One record per **(day, model, upstream provider, endpoint)** - the activity API's
+own grain - with real credit spend
+(`usage`, in USD) as the billed cost.
+
+Provider name (for `--provider`): `openrouter`
+
+## Environment variables
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `OPENROUTER_MANAGEMENT_KEY` | yes | A **management** key (from openrouter.ai/settings/management-keys). A normal `sk-or-v1-` inference key returns `403 - Only management keys can perform this operation`. |
+| `OPENROUTER_ORG_ID` | yes | Sets `BillingAccountId` (mandatory FOCUS column; the activity API returns no account id). |
+
+The key is sent as `Authorization: Bearer <key>`.
+
+## API endpoints used
+
+Base URL: `https://openrouter.ai`
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /api/v1/activity?date=YYYY-MM-DD` | Per-model, per-provider usage and cost for a single UTC day. |
+
+The adapter iterates the requested window day by day, restricted to the last ~30
+completed UTC days (it never requests the current incomplete day). Dates outside
+the last ~30 completed UTC days return HTTP 400; the adapter logs and skips them.
+
+## FOCUS mapping
+
+| FOCUS column | Source |
+| --- | --- |
+| `BilledCost` / `EffectiveCost` / `ListCost` / `ContractedCost` | `usage` (credit spend, USD) |
+| `BillingCurrency` / `PricingCurrency` | `USD` (credits are USD) |
+| `ChargePeriodStart` / `ChargePeriodEnd` | the day |
+| `ConsumedQuantity` / `ConsumedUnit` | `prompt_tokens + completion_tokens` / `tokens` |
+| `PricingQuantity` / `PricingUnit` | tokens / 1e6, `1M tokens` |
+| `ListUnitPrice` / `ContractedUnitPrice` | `usage` / (tokens / 1e6) - blended per-MTok rate |
+| `ServiceName`, `SkuId`, `ResourceId`/`Name` | `model` |
+| `Provider` / `Publisher` / `InvoiceIssuer` | `OpenRouter` |
+| `ServiceCategory` / `ServiceSubcategory` | `AI and Machine Learning` / `Generative AI` |
+| `SkuMeter` / `SkuPriceId` | upstream `provider_name` / `model\|provider_name` |
+| `x_UpstreamProvider` | `provider_name` (e.g. OpenAI, Anthropic) |
+| `x_PromptTokens` / `x_CompletionTokens` / `x_ReasoningTokens` | token counts |
+| `x_ModelRequests` | `requests` |
+| `x_ModelPermaslug` | `model_permaslug` |
+| `x_EndpointId` | `endpoint_id` |
+| `x_ByokUsage` / `x_ByokRequests` | `byok_usage_inference` / `byok_requests` (see below) |
+
+## Example
+
+```bash
+export OPENROUTER_MANAGEMENT_KEY=sk-or-...
+focus-exporter --provider openrouter --start 2026-07-01 --end 2026-08-01 --format json
+```
+
+## Notes and limitations
+
+- **A window is required** and capped to the last ~30 completed UTC days by the
+  API. Pass `--start`/`--end` (or `--month`); the adapter clamps the request to
+  that window and skips the current incomplete day.
+- **BYOK spend is kept out of `BilledCost`.** `byok_usage_inference` is spend that
+  routed through your own upstream provider keys - OpenRouter did not bill it, and
+  it would double-count against your direct provider bill. It is carried as
+  `x_ByokUsage` for visibility only.
+- **Cost is per (model, provider), not per token bucket.** OpenRouter reports one
+  `usage` figure per model/provider per day, so cost is not split into input vs
+  output; the token breakdown rides as `x_` extensions.
+- **Gateway fees are not captured (API gap).** Reported `BilledCost` is inference
+  credit spend only. OpenRouter's revenue also comes from a deposit fee (~5% +
+  a fixed amount on each credit top-up) and the BYOK surcharge, but the API
+  exposes neither: `/api/v1/credits` returns only aggregate
+  `total_credits`/`total_usage`, and there is no transactions endpoint. So total
+  `BilledCost` understates actual cash paid to OpenRouter by the deposit fee. If
+  a transactions/fee API appears, those would be emitted as
+  `ChargeCategory = "Purchase"` records (see the charge-completeness rule in
+  AGENTS.md); until then they cannot be reported without fabricating them.
+- Wait ~30 minutes past a UTC day boundary before pulling that day (late-finishing
+  requests are attributed by start time). Dates outside the last ~30 completed UTC
+  days return HTTP 400; the adapter logs and skips them rather than failing the run.
+- **Grain is per endpoint.** A model on one provider can have several endpoints
+  (e.g. different quantizations or regions); each is its own activity row and its
+  own record, distinguished by `x_EndpointId`. Cost is not aggregated across
+  endpoints, so per-endpoint spend is preserved.
+- Verified end-to-end against a live management key (real per-model, per-provider
+  spend across OpenAI / Azure / Amazon Bedrock upstreams).

--- a/costgraph/focus-exporter/overview.mdx
+++ b/costgraph/focus-exporter/overview.mdx
@@ -1,0 +1,44 @@
+---
+title: FOCUS Exporter
+description: "Per-provider setup guides for the open-source FOCUS exporter, which pulls each vendor's cost API and emits FOCUS 1.2 records."
+---
+
+The [focus-exporter](https://github.com/baselinehq/focus-exporter) is an
+open-source CLI that pulls a provider's own cost/usage API and emits FOCUS 1.2
+records, which you can write to a file or push to CostGraph. The guides below
+cover the credentials and configuration each provider needs.
+
+Each provider is a small adapter behind one interface (`integrations.Source`)
+that pulls that vendor's own cost/usage API and returns `[]model.UsageRecord`;
+`pkg/focus` maps those into FOCUS 1.2 records before the sinks write them. This
+directory documents, per provider, the credentials and configuration needed to
+run an export.
+
+## Available
+
+| Provider | Domain | Auth | Doc |
+| --- | --- | --- | --- |
+| PlanetScale | Managed database (infra cost) | Service token | [Guide](/costgraph/focus-exporter/planetscale) |
+| Anthropic | AI model cost | Admin API key | [Guide](/costgraph/focus-exporter/anthropic) |
+| OpenAI | AI model cost | Admin API key | [Guide](/costgraph/focus-exporter/openai) |
+| Confluent Cloud | Event streaming (Kafka) | Cloud API key | [Guide](/costgraph/focus-exporter/confluent) |
+| GitHub | Developer platform / CI | Personal access token | [Guide](/costgraph/focus-exporter/github) |
+| OpenRouter | AI gateway (multi-provider) | Management key | [Guide](/costgraph/focus-exporter/openrouter) |
+| Modal | Serverless GPU / compute | Token id + secret | [Guide](/costgraph/focus-exporter/modal) |
+| RespanAI | AI gateway / observability | API key | [Guide](/costgraph/focus-exporter/respanai) |
+| Helicone | AI gateway / observability | API key | [Guide](/costgraph/focus-exporter/helicone) |
+
+## Documenting a new provider
+
+Copy the structure of [Guide](/costgraph/focus-exporter/planetscale):
+
+1. **Overview** - what the provider bills for and the FOCUS grain (one record per what).
+2. **Environment variables** - a table: name, required, description.
+3. **Credential setup** - step-by-step to obtain the credential, and the minimum
+   scopes/permissions it needs.
+4. **API endpoints used** - the exact endpoints the adapter calls, so operators
+   can reason about access and rate limits.
+5. **FOCUS mapping** - a table from FOCUS column to provider field, including any
+   `x_` extension columns.
+6. **Example** - a runnable command and a representative output record.
+7. **Notes and limitations** - granularity, currency, known gaps.

--- a/costgraph/focus-exporter/planetscale.mdx
+++ b/costgraph/focus-exporter/planetscale.mdx
@@ -1,0 +1,147 @@
+---
+title: PlanetScale
+description: "Exports one FOCUS 1.2 record per (invoice month, database, billing metric) from the PlanetScale billing API. Cost is the real billed subtotal from the..."
+---
+
+Exports one FOCUS 1.2 record per **(invoice month, database, billing metric)**
+from the PlanetScale billing API. Cost is the real billed `subtotal` from the
+invoice - not an estimate - so credits, prorations, and plan minimums are
+reflected exactly as PlanetScale charged them.
+
+Provider name (for `--provider`): `planetscale`
+
+## Environment variables
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `PLANETSCALE_SERVICE_TOKEN_ID` | yes | The service token's ID (the short public identifier, not the secret). |
+| `PLANETSCALE_SERVICE_TOKEN` | yes | The service token secret (`pscale_tkn_...`). Treat as a credential; never commit it. |
+
+The organization is resolved from `GET /v1/organizations`, which returns the one the service token is scoped to, so it is never configured.
+
+The token is sent as `Authorization: <id>:<token>` on every request.
+
+## Credential setup
+
+PlanetScale [service tokens](https://api-docs.planetscale.com/reference/service-tokens)
+are the recommended machine credential (they are not tied to a user account).
+
+1. In the PlanetScale dashboard, go to **Settings -> Service tokens** for the
+   organization, or use the CLI:
+   ```bash
+   pscale service-token create --org your-org
+   ```
+   This prints the token **ID** and the **token secret**. The secret is shown
+   once - store it securely.
+2. Grant the token the permissions it needs (see below):
+   ```bash
+   pscale service-token add-access <token-id> \
+     read_organizations read_databases \
+     --org your-org
+   ```
+3. Export both variables:
+   ```bash
+   export PLANETSCALE_SERVICE_TOKEN_ID=<token-id>
+   export PLANETSCALE_SERVICE_TOKEN=pscale_tkn_...
+   ```
+
+### Minimum permissions
+
+The exporter only reads. It needs organization-level read access to invoices
+and databases:
+
+- `read_organizations` - list the org and read its invoices and line items.
+- `read_databases` - list databases (used to resolve region and plan for each
+  line item).
+
+No write, branch, or connection-string access is required. Scope the token to
+read-only.
+
+## API endpoints used
+
+Base URL: `https://api.planetscale.com`
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /v1/organizations/{org}/invoices` | List invoices; each carries `billing_period_start` / `billing_period_end`. |
+| `GET /v1/organizations/{org}/invoices/{id}/line-items` | Per-invoice line items: `metric_name`, `subtotal`, `database_id`, `database_name`. |
+| `GET /v1/organizations/{org}/databases` | Resolve `region` (slug + display name + cloud) and `plan` for each database. |
+
+All are paginated (`page`, `per_page=100`) and followed to completion. Only
+invoices whose billing period overlaps the requested `--start`/`--end` window
+are fetched for line items.
+
+## FOCUS mapping
+
+| FOCUS column | Source |
+| --- | --- |
+| `BilledCost`, `EffectiveCost`, `ListCost` | line-item `subtotal` (there is no separate negotiated rate on the invoice) |
+| `BillingCurrency` | `USD` |
+| `ChargePeriodStart` / `ChargePeriodEnd` | invoice `billing_period_start` / `billing_period_end` |
+| `BillingPeriodStart` / `BillingPeriodEnd` | same as charge period |
+| `ChargeCategory` | `Usage`, or `Credit` when the line item has a negative `subtotal` (prorated discounts, refunds) |
+| `ChargeDescription` | line-item `description` (falls back to `metric_name` when absent) |
+| `ServiceName`, `Provider` | `PlanetScale` |
+| `ServiceCategory` | `Databases` |
+| `ServiceSubcategory` | `Managed Database` |
+| `ResourceId` / `ResourceName` | `database_id` / `database_name` |
+| `ResourceType` | `Database` |
+| `RegionId` / `RegionName` | database `region.slug` / `region.display_name` (via the databases join) |
+| `SkuId` | database `plan` |
+| `SkuMeter` | `metric_name` |
+| `SkuPriceId` | `plan\|metric_name` (or `metric_name` alone when the database is not in the join) |
+| `x_InfraProvider` | database `region.provider` (`aws` / `gcp`) - the sole vendor-specific extension |
+
+## Example
+
+```bash
+export PLANETSCALE_SERVICE_TOKEN_ID=xxxxxxxxxxxx
+export PLANETSCALE_SERVICE_TOKEN=pscale_tkn_...
+
+focus-exporter --provider planetscale --month 2026-07 --format json
+```
+
+Representative record:
+
+```json
+{
+  "BilledCost": "30.0",
+  "EffectiveCost": "30.0",
+  "ListCost": "30.0",
+  "BillingCurrency": "USD",
+  "ChargePeriodStart": "2026-07-01T00:00:00Z",
+  "ChargePeriodEnd": "2026-08-01T00:00:00Z",
+  "Provider": "PlanetScale",
+  "ServiceName": "PlanetScale",
+  "ServiceCategory": "Databases",
+  "ServiceSubcategory": "Managed Database",
+  "ChargeCategory": "Usage",
+  "ResourceId": "7p5sqtyldrf6",
+  "ResourceName": "pscale-1",
+  "ResourceType": "Database",
+  "RegionId": "us-east",
+  "RegionName": "AWS us-east-1",
+  "SkuId": "scaler_pro",
+  "SkuMeter": "PS_10_AWS_ARM",
+  "ChargeDescription": "PS-10-AWS-ARM for branch 'main'",
+  "SkuPriceId": "scaler_pro|PS_10_AWS_ARM",
+  "x_InfraProvider": "AWS"
+}
+```
+
+## Notes and limitations
+
+- **Granularity is monthly.** The invoices API exposes only monthly line items,
+  so `ChargePeriod` equals `BillingPeriod` (the calendar month). There is no
+  finer charge granularity from this source.
+- **Currency is USD.** PlanetScale invoices are billed in USD.
+- **Credits and prorations** appear as their own line items with a negative
+  `subtotal` (e.g. PlanetScale bills the full plan up front, then credits back
+  the unused portion when a branch is deleted mid-period). They are surfaced
+  as-is with negative `BilledCost` and `ChargeCategory = "Credit"`, and their
+  `ChargeDescription` carries the provider's own text ("Prorated ... discount").
+- **Unmatched databases** (a line item whose `database_id` is not in the
+  databases list, e.g. a deleted database) are still emitted, with region and
+  plan left empty rather than dropped.
+- A single invoice that fails to fetch or has an unparseable billing period is
+  logged and skipped; it never aborts the whole export.

--- a/costgraph/focus-exporter/respanai.mdx
+++ b/costgraph/focus-exporter/respanai.mdx
@@ -1,0 +1,70 @@
+---
+title: RespanAI
+description: "Formerly KeywordsAI."
+---
+
+Formerly KeywordsAI.
+
+Exports FOCUS 1.2 records from the RespanAI request-logs API.
+RespanAI is an LLM gateway/observability layer, so one integration captures
+spend across every model and upstream provider you route through it. One record
+per **(day, model, upstream provider)**, aggregated from per-request logs.
+
+Provider name (for `--provider`): `respanai`
+
+## Environment variables
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `RESPANAI_API_KEY` | yes | API key, sent as `Authorization: Bearer <key>`. |
+| `RESPANAI_ORG_ID` | yes | Populates the mandatory `BillingAccountId` (the logs API returns no account id). |
+| `RESPANAI_TENANT_FIELD` | no | Splits spend per downstream tenant into the FOCUS sub-account columns. Set to `customer_identifier` to use each log's customer id, or to a key in each log's `metadata`. See [tenancy.md](../tenancy.md). |
+
+## API endpoints used
+
+Base URL: `https://api.respan.ai`
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /api/request-logs/list/?start_time&end_time&page_size` | Per-request logs over the window. The adapter follows `next` until the last page and rolls the rows up by (day, model, provider) client-side. |
+
+There is no server-side per-model/provider/day aggregation endpoint, so the
+adapter paginates the log list and aggregates locally.
+
+## FOCUS mapping
+
+| FOCUS column | Source |
+| --- | --- |
+| `BilledCost` / `EffectiveCost` / `ListCost` / `ContractedCost` | sum of `cost` (USD) over the bucket |
+| `BillingCurrency` / `PricingCurrency` | `USD` (the logs API returns no currency) |
+| `ChargePeriodStart` / `ChargePeriodEnd` | the day (from `timestamp`) |
+| `ConsumedQuantity` / `ConsumedUnit` | `prompt_tokens + completion_tokens` / `tokens` |
+| `ServiceName`, `SkuId`, `ResourceId`/`Name` | `model` |
+| `Provider` / `Publisher` / `InvoiceIssuer` | `RespanAI` |
+| `ServiceCategory` / `ServiceSubcategory` | `AI and Machine Learning` / `Generative AI` |
+| `SkuMeter` / `SkuPriceId` | `provider_id` / `model\|provider_id` |
+| `x_UpstreamProvider` | `provider_id` |
+| `x_PromptTokens` / `x_CompletionTokens` | token counts |
+| `BillingAccountId` | `RESPANAI_ORG_ID` |
+| `SubAccountId` / `SubAccountName` / `SubAccountType` | the `RESPANAI_TENANT_FIELD` value on each log (only when that env is set) |
+
+## Example
+
+```bash
+export RESPANAI_API_KEY=...
+export RESPANAI_ORG_ID=your-org
+focus-exporter --provider respanai --start 2026-07-01 --end 2026-08-01 --format json
+```
+
+## Notes and limitations
+
+- **A window is required.** Pass `--start`/`--end` or `--month`; the list API
+  otherwise defaults to the last hour.
+- **Cost is per (model, provider), not per token bucket.** The logs carry one
+  `cost` per request; the adapter sums it per day/model/provider and does not
+  split input vs output pricing (token counts ride as `x_` extensions).
+- **Gateway credit fees are not captured (API gap).** Reported `BilledCost` is
+  request spend from the logs. Respan's own platform/credit charges are not
+  in the logs endpoint, so - as with OpenRouter - they are not reported here; if
+  a billing/transactions API is added they map to `ChargeCategory = "Purchase"`
+  (see the charge-completeness rule in AGENTS.md).

--- a/costgraph/focus-exporter/sinks.mdx
+++ b/costgraph/focus-exporter/sinks.mdx
@@ -1,0 +1,58 @@
+---
+title: Sinks
+description: "A sink decides where the exported FOCUS records go. The --sink flag only selects the sink; each sink is configured entirely from the environment, so adding..."
+---
+
+A sink decides where the exported FOCUS records go. The `--sink` flag only
+selects the sink; each sink is configured entirely from the environment, so
+adding a new sink never adds a new flag.
+
+| `--sink` | Destination | Default |
+| --- | --- | --- |
+| `file` | stdout or a file | yes |
+| `costgraph` | costgraph ingest endpoint | - |
+
+## `file`
+
+Writes the records to stdout, or to `--out <path>`, in the format chosen by
+`--format`.
+
+| Flag | Meaning | Default |
+| --- | --- | --- |
+| `--format` | `json` or `csv` | `json` |
+| `-o`, `--out` | Output file | stdout |
+
+```bash
+focus-exporter --provider planetscale --month 2026-07 --format csv -o july.csv
+```
+
+## `costgraph`
+
+POSTs the records straight to costgraph's ingest endpoint
+(`/api/v1/tenant/billing/focus`) instead of writing a file, authenticated with a
+`focus:write` API key. The run's window is sent as a full-window replace, so
+re-running the same window is idempotent.
+
+A push is tied to one connection and provider (the backend rejects
+mixed-provider rows), so `--sink costgraph` requires exactly one `--provider`
+and an explicit window (`--month` or `--start`/`--end`). `--format` is ignored.
+
+| Env | Meaning | Default |
+| --- | --- | --- |
+| `COSTGRAPH_API_KEY` | `focus:write` API key. Treat as a credential; never commit it. | required |
+| `COSTGRAPH_CONNECTION_ID` | Integration connection id (`fpc_...`). | required |
+| `COSTGRAPH_URL` | Costgraph base URL. | `https://api.costgraph.ai` |
+
+```bash
+COSTGRAPH_API_KEY=... COSTGRAPH_CONNECTION_ID=fpc_... focus-exporter \
+  --provider planetscale --month 2026-07 --sink costgraph
+```
+
+If the payload exceeds the backend's size limit the push fails with a `413` and
+a message telling you to narrow the window.
+
+## Adding a sink
+
+Implement the `Sink` interface in `pkg/sink` (`Write(recs []focus.Record) error`),
+read its config from the environment, and wire it into the `--sink` switch in
+`cmd/focus-exporter/main.go`. No new flags.

--- a/docs.json
+++ b/docs.json
@@ -76,6 +76,26 @@
               "costgraph/integrations/planetscale",
               "costgraph/integrations/respanai"
             ]
+          },
+          {
+            "group": "FOCUS Exporter",
+            "icon": "file-export",
+            "pages": [
+              "costgraph/focus-exporter/overview",
+              "costgraph/focus-exporter/sinks",
+              "costgraph/focus-exporter/anthropic",
+              "costgraph/focus-exporter/cloudflare",
+              "costgraph/focus-exporter/confluent",
+              "costgraph/focus-exporter/digitalocean",
+              "costgraph/focus-exporter/github",
+              "costgraph/focus-exporter/grafanacloud",
+              "costgraph/focus-exporter/helicone",
+              "costgraph/focus-exporter/modal",
+              "costgraph/focus-exporter/openai",
+              "costgraph/focus-exporter/openrouter",
+              "costgraph/focus-exporter/planetscale",
+              "costgraph/focus-exporter/respanai"
+            ]
           }
         ]
       },


### PR DESCRIPTION
Publishes the focus-exporter per-provider docs as a new **FOCUS Exporter** section under CostGraph, so the setup guides are public and deep-linkable.

- New `costgraph/focus-exporter/*`: overview, sinks reference, and 12 provider guides (anthropic, cloudflare, confluent, digitalocean, github, grafanacloud, helicone, modal, openai, openrouter, planetscale, respanai), converted from the exporter repo's `docs/providers/*.md`.
- Added the section to `docs.json` navigation.
- Overview links back to the open-source repo.

Paired with focus-exporter changes that repoint each provider's registry `DocsURL` to `https://docs.costgraph.ai/costgraph/focus-exporter/<slug>`, so the dashboard's served setup-guide links land here. Distinct from the existing platform `integrations/*` connect pages (different audience) - those are untouched.