### PR TITLE
docs: add focus-exporter provider integration pages

### DIFF
--- a/costgraph/integrations/anthropic.mdx
+++ b/costgraph/integrations/anthropic.mdx
@@ -7,12 +7,6 @@ Anthropic bills API usage per model and token bucket, so model spend lands besid
 
 CostGraph reads Anthropic as **FOCUS 1.2** records at a grain of day x model x token bucket (cost + tokens).
 
-<Card title="Anthropic reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/anthropic.md">
-  The credentials and permissions Anthropic needs, every environment variable, the API
-  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
-  never drifts from the code.
-</Card>
-
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
@@ -48,8 +42,7 @@ Anthropic at any time and the connection stops; nothing else is affected.
 1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider anthropic`, following the
-   [Anthropic reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/anthropic.md) for the environment it needs.
+4. Run the exporter with `--provider anthropic`.
 5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it

--- a/costgraph/integrations/cloudflare.mdx
+++ b/costgraph/integrations/cloudflare.mdx
@@ -1,0 +1,59 @@
+---
+title: Cloudflare
+description: "Bring Cloudflare cost into CostGraph, pulled by us or pushed by you"
+---
+
+Cloudflare bills billable usage per product across your account, so spend is attributed per service.
+
+CostGraph reads Cloudflare as **FOCUS 1.2** records at a grain of day x service (billable usage).
+
+<Card title="Cloudflare reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/cloudflare.md">
+  The credentials and permissions Cloudflare needs, every environment variable, the API
+  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
+  never drifts from the code.
+</Card>
+
+## Choose how the data reaches us
+
+<CardGroup cols={2}>
+  <Card title="CostGraph pulls it" icon="cloud-arrow-down">
+    You supply read-only credentials and we call Cloudflare once a day. Nothing to run.
+  </Card>
+  <Card title="You push it" icon="cloud-arrow-up">
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
+    Credentials never leave your infrastructure.
+  </Card>
+</CardGroup>
+
+## Let CostGraph pull
+
+1. Open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **Cloudflare**, name the connection, and enter the billing account these
+   charges belong to.
+3. Fill in the values the form asks for. It lists exactly the variables Cloudflare
+   needs, marks which are optional, and links this provider's reference for the
+   permissions each one requires.
+4. Select **Connect**.
+
+CostGraph verifies the credentials with a short fetch before saving, so a wrong
+value or a missing permission fails while you are still on the form.
+
+<Note>
+Credentials are encrypted at rest and used only to read billing data. Revoke them in
+Cloudflare at any time and the connection stops; nothing else is affected.
+</Note>
+
+## Push it yourself
+
+1. Open **Settings -> Integrations** and pick **FOCUS push**.
+2. Create the connection and copy its **Connection ID**.
+3. Create a CostGraph API key with the `focus:write` scope.
+4. Run the exporter with `--provider cloudflare`, following the
+   [Cloudflare reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/cloudflare.md) for the environment it needs.
+5. Send the records to CostGraph, quoting the connection id and API key.
+
+## What CostGraph does with it
+
+Records land as raw billing rows, are normalised into line items, and roll up into
+daily cost. From there Cloudflare spend appears in Cost Overview and in anomaly
+detection alongside every other provider.

--- a/costgraph/integrations/cloudflare.mdx
+++ b/costgraph/integrations/cloudflare.mdx
@@ -7,12 +7,6 @@ Cloudflare bills billable usage per product across your account, so spend is att
 
 CostGraph reads Cloudflare as **FOCUS 1.2** records at a grain of day x service (billable usage).
 
-<Card title="Cloudflare reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/cloudflare.md">
-  The credentials and permissions Cloudflare needs, every environment variable, the API
-  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
-  never drifts from the code.
-</Card>
-
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
@@ -48,8 +42,7 @@ Cloudflare at any time and the connection stops; nothing else is affected.
 1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider cloudflare`, following the
-   [Cloudflare reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/cloudflare.md) for the environment it needs.
+4. Run the exporter with `--provider cloudflare`.
 5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it

--- a/costgraph/integrations/confluent.mdx
+++ b/costgraph/integrations/confluent.mdx
@@ -7,12 +7,6 @@ Confluent Cloud bills per product and resource, so Kafka spend is attributed per
 
 CostGraph reads Confluent Cloud as **FOCUS 1.2** records at a grain of billing line item (product x resource).
 
-<Card title="Confluent Cloud reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/confluent.md">
-  The credentials and permissions Confluent Cloud needs, every environment variable, the API
-  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
-  never drifts from the code.
-</Card>
-
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
@@ -48,8 +42,7 @@ Confluent Cloud at any time and the connection stops; nothing else is affected.
 1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider confluent`, following the
-   [Confluent Cloud reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/confluent.md) for the environment it needs.
+4. Run the exporter with `--provider confluent`.
 5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it

--- a/costgraph/integrations/cursor.mdx
+++ b/costgraph/integrations/cursor.mdx
@@ -1,0 +1,59 @@
+---
+title: Cursor
+description: "Bring Cursor cost into CostGraph, pulled by us or pushed by you"
+---
+
+Cursor bills team usage per model, so spend is attributed per model across your team.
+
+CostGraph reads Cursor as **FOCUS 1.2** records at a grain of day x model (team usage events).
+
+<Card title="Cursor reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/cursor.md">
+  The credentials and permissions Cursor needs, every environment variable, the API
+  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
+  never drifts from the code.
+</Card>
+
+## Choose how the data reaches us
+
+<CardGroup cols={2}>
+  <Card title="CostGraph pulls it" icon="cloud-arrow-down">
+    You supply read-only credentials and we call Cursor once a day. Nothing to run.
+  </Card>
+  <Card title="You push it" icon="cloud-arrow-up">
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
+    Credentials never leave your infrastructure.
+  </Card>
+</CardGroup>
+
+## Let CostGraph pull
+
+1. Open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **Cursor**, name the connection, and enter the billing account these
+   charges belong to.
+3. Fill in the values the form asks for. It lists exactly the variables Cursor
+   needs, marks which are optional, and links this provider's reference for the
+   permissions each one requires.
+4. Select **Connect**.
+
+CostGraph verifies the credentials with a short fetch before saving, so a wrong
+value or a missing permission fails while you are still on the form.
+
+<Note>
+Credentials are encrypted at rest and used only to read billing data. Revoke them in
+Cursor at any time and the connection stops; nothing else is affected.
+</Note>
+
+## Push it yourself
+
+1. Open **Settings -> Integrations** and pick **FOCUS push**.
+2. Create the connection and copy its **Connection ID**.
+3. Create a CostGraph API key with the `focus:write` scope.
+4. Run the exporter with `--provider cursor`, following the
+   [Cursor reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/cursor.md) for the environment it needs.
+5. Send the records to CostGraph, quoting the connection id and API key.
+
+## What CostGraph does with it
+
+Records land as raw billing rows, are normalised into line items, and roll up into
+daily cost. From there Cursor spend appears in Cost Overview and in anomaly
+detection alongside every other provider.

--- a/costgraph/integrations/cursor.mdx
+++ b/costgraph/integrations/cursor.mdx
@@ -7,12 +7,6 @@ Cursor bills team usage per model, so spend is attributed per model across your 
 
 CostGraph reads Cursor as **FOCUS 1.2** records at a grain of day x model (team usage events).
 
-<Card title="Cursor reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/cursor.md">
-  The credentials and permissions Cursor needs, every environment variable, the API
-  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
-  never drifts from the code.
-</Card>
-
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
@@ -48,8 +42,7 @@ Cursor at any time and the connection stops; nothing else is affected.
 1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider cursor`, following the
-   [Cursor reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/cursor.md) for the environment it needs.
+4. Run the exporter with `--provider cursor`.
 5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it

--- a/costgraph/integrations/digitalocean.mdx
+++ b/costgraph/integrations/digitalocean.mdx
@@ -1,0 +1,59 @@
+---
+title: DigitalOcean
+description: "Bring DigitalOcean cost into CostGraph, pulled by us or pushed by you"
+---
+
+DigitalOcean bills per line item across your account, so spend is attributed per product and resource.
+
+CostGraph reads DigitalOcean as **FOCUS 1.2** records at a grain of billing line item.
+
+<Card title="DigitalOcean reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/digitalocean.md">
+  The credentials and permissions DigitalOcean needs, every environment variable, the API
+  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
+  never drifts from the code.
+</Card>
+
+## Choose how the data reaches us
+
+<CardGroup cols={2}>
+  <Card title="CostGraph pulls it" icon="cloud-arrow-down">
+    You supply read-only credentials and we call DigitalOcean once a day. Nothing to run.
+  </Card>
+  <Card title="You push it" icon="cloud-arrow-up">
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
+    Credentials never leave your infrastructure.
+  </Card>
+</CardGroup>
+
+## Let CostGraph pull
+
+1. Open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **DigitalOcean**, name the connection, and enter the billing account these
+   charges belong to.
+3. Fill in the values the form asks for. It lists exactly the variables DigitalOcean
+   needs, marks which are optional, and links this provider's reference for the
+   permissions each one requires.
+4. Select **Connect**.
+
+CostGraph verifies the credentials with a short fetch before saving, so a wrong
+value or a missing permission fails while you are still on the form.
+
+<Note>
+Credentials are encrypted at rest and used only to read billing data. Revoke them in
+DigitalOcean at any time and the connection stops; nothing else is affected.
+</Note>
+
+## Push it yourself
+
+1. Open **Settings -> Integrations** and pick **FOCUS push**.
+2. Create the connection and copy its **Connection ID**.
+3. Create a CostGraph API key with the `focus:write` scope.
+4. Run the exporter with `--provider digitalocean`, following the
+   [DigitalOcean reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/digitalocean.md) for the environment it needs.
+5. Send the records to CostGraph, quoting the connection id and API key.
+
+## What CostGraph does with it
+
+Records land as raw billing rows, are normalised into line items, and roll up into
+daily cost. From there DigitalOcean spend appears in Cost Overview and in anomaly
+detection alongside every other provider.

--- a/costgraph/integrations/digitalocean.mdx
+++ b/costgraph/integrations/digitalocean.mdx
@@ -7,12 +7,6 @@ DigitalOcean bills per line item across your account, so spend is attributed per
 
 CostGraph reads DigitalOcean as **FOCUS 1.2** records at a grain of billing line item.
 
-<Card title="DigitalOcean reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/digitalocean.md">
-  The credentials and permissions DigitalOcean needs, every environment variable, the API
-  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
-  never drifts from the code.
-</Card>
-
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
@@ -48,8 +42,7 @@ DigitalOcean at any time and the connection stops; nothing else is affected.
 1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider digitalocean`, following the
-   [DigitalOcean reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/digitalocean.md) for the environment it needs.
+4. Run the exporter with `--provider digitalocean`.
 5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it

--- a/costgraph/integrations/github.mdx
+++ b/costgraph/integrations/github.mdx
@@ -9,12 +9,6 @@ organization, so a single connection captures the lot.
 CostGraph reads GitHub as **FOCUS 1.2** records at a grain of day x product x SKU x
 repository, carrying both gross and net billed cost.
 
-<Card title="GitHub reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/github.md">
-  The credentials and permissions GitHub needs, every environment variable, the API
-  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
-  never drifts from the code.
-</Card>
-
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
@@ -49,8 +43,7 @@ in GitHub at any time and the connection stops; nothing else is affected.
 1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider github`, following the
-   [GitHub reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/github.md) for the environment it needs.
+4. Run the exporter with `--provider github`.
 5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it

--- a/costgraph/integrations/grafanacloud.mdx
+++ b/costgraph/integrations/grafanacloud.mdx
@@ -7,12 +7,6 @@ Grafana Cloud bills usage per billing dimension, so spend is attributed per mete
 
 CostGraph reads Grafana Cloud as **FOCUS 1.2** records at a grain of day x billing dimension.
 
-<Card title="Grafana Cloud reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/grafanacloud.md">
-  The credentials and permissions Grafana Cloud needs, every environment variable, the API
-  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
-  never drifts from the code.
-</Card>
-
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
@@ -48,8 +42,7 @@ Grafana Cloud at any time and the connection stops; nothing else is affected.
 1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider grafanacloud`, following the
-   [Grafana Cloud reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/grafanacloud.md) for the environment it needs.
+4. Run the exporter with `--provider grafanacloud`.
 5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it

--- a/costgraph/integrations/grafanacloud.mdx
+++ b/costgraph/integrations/grafanacloud.mdx
@@ -1,0 +1,59 @@
+---
+title: Grafana Cloud
+description: "Bring Grafana Cloud cost into CostGraph, pulled by us or pushed by you"
+---
+
+Grafana Cloud bills usage per billing dimension, so spend is attributed per metered dimension across your org.
+
+CostGraph reads Grafana Cloud as **FOCUS 1.2** records at a grain of day x billing dimension.
+
+<Card title="Grafana Cloud reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/grafanacloud.md">
+  The credentials and permissions Grafana Cloud needs, every environment variable, the API
+  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
+  never drifts from the code.
+</Card>
+
+## Choose how the data reaches us
+
+<CardGroup cols={2}>
+  <Card title="CostGraph pulls it" icon="cloud-arrow-down">
+    You supply read-only credentials and we call Grafana Cloud once a day. Nothing to run.
+  </Card>
+  <Card title="You push it" icon="cloud-arrow-up">
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
+    Credentials never leave your infrastructure.
+  </Card>
+</CardGroup>
+
+## Let CostGraph pull
+
+1. Open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **Grafana Cloud**, name the connection, and enter the billing account these
+   charges belong to.
+3. Fill in the values the form asks for. It lists exactly the variables Grafana Cloud
+   needs, marks which are optional, and links this provider's reference for the
+   permissions each one requires.
+4. Select **Connect**.
+
+CostGraph verifies the credentials with a short fetch before saving, so a wrong
+value or a missing permission fails while you are still on the form.
+
+<Note>
+Credentials are encrypted at rest and used only to read billing data. Revoke them in
+Grafana Cloud at any time and the connection stops; nothing else is affected.
+</Note>
+
+## Push it yourself
+
+1. Open **Settings -> Integrations** and pick **FOCUS push**.
+2. Create the connection and copy its **Connection ID**.
+3. Create a CostGraph API key with the `focus:write` scope.
+4. Run the exporter with `--provider grafanacloud`, following the
+   [Grafana Cloud reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/grafanacloud.md) for the environment it needs.
+5. Send the records to CostGraph, quoting the connection id and API key.
+
+## What CostGraph does with it
+
+Records land as raw billing rows, are normalised into line items, and roll up into
+daily cost. From there Grafana Cloud spend appears in Cost Overview and in anomaly
+detection alongside every other provider.

--- a/costgraph/integrations/helicone.mdx
+++ b/costgraph/integrations/helicone.mdx
@@ -7,12 +7,6 @@ Helicone is an LLM gateway, so one connection captures spend across every model 
 
 CostGraph reads Helicone as **FOCUS 1.2** records at a grain of day x model x upstream provider (request spend).
 
-<Card title="Helicone reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/helicone.md">
-  The credentials and permissions Helicone needs, every environment variable, the API
-  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
-  never drifts from the code.
-</Card>
-
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
@@ -48,8 +42,7 @@ Helicone at any time and the connection stops; nothing else is affected.
 1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider helicone`, following the
-   [Helicone reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/helicone.md) for the environment it needs.
+4. Run the exporter with `--provider helicone`.
 5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it

--- a/costgraph/integrations/modal.mdx
+++ b/costgraph/integrations/modal.mdx
@@ -7,12 +7,6 @@ Modal bills serverless GPU and compute per object, so per-function CPU, memory, 
 
 CostGraph reads Modal as **FOCUS 1.2** records at a grain of day x object (per-resource CPU/mem/GPU cost).
 
-<Card title="Modal reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/modal.md">
-  The credentials and permissions Modal needs, every environment variable, the API
-  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
-  never drifts from the code.
-</Card>
-
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
@@ -48,8 +42,7 @@ Modal at any time and the connection stops; nothing else is affected.
 1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider modal`, following the
-   [Modal reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/modal.md) for the environment it needs.
+4. Run the exporter with `--provider modal`.
 5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it

--- a/costgraph/integrations/openai.mdx
+++ b/costgraph/integrations/openai.mdx
@@ -7,12 +7,6 @@ OpenAI bills API usage per model and token bucket, so model spend lands beside y
 
 CostGraph reads OpenAI as **FOCUS 1.2** records at a grain of day x model x token bucket (billed cost + quantity).
 
-<Card title="OpenAI reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openai.md">
-  The credentials and permissions OpenAI needs, every environment variable, the API
-  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
-  never drifts from the code.
-</Card>
-
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
@@ -48,8 +42,7 @@ OpenAI at any time and the connection stops; nothing else is affected.
 1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider openai`, following the
-   [OpenAI reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openai.md) for the environment it needs.
+4. Run the exporter with `--provider openai`.
 5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it

--- a/costgraph/integrations/openrouter.mdx
+++ b/costgraph/integrations/openrouter.mdx
@@ -7,12 +7,6 @@ OpenRouter routes requests to many upstream models, so one connection captures c
 
 CostGraph reads OpenRouter as **FOCUS 1.2** records at a grain of day x model x upstream provider (credit spend).
 
-<Card title="OpenRouter reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openrouter.md">
-  The credentials and permissions OpenRouter needs, every environment variable, the API
-  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
-  never drifts from the code.
-</Card>
-
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
@@ -48,8 +42,7 @@ OpenRouter at any time and the connection stops; nothing else is affected.
 1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider openrouter`, following the
-   [OpenRouter reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/openrouter.md) for the environment it needs.
+4. Run the exporter with `--provider openrouter`.
 5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it

--- a/costgraph/integrations/ovhcloud.mdx
+++ b/costgraph/integrations/ovhcloud.mdx
@@ -7,12 +7,6 @@ OVHcloud bills monthly across every product, so spend is attributed per bill lin
 
 CostGraph reads OVHcloud as **FOCUS 1.2** records at a grain of bill line item.
 
-<Card title="OVHcloud reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/ovhcloud.md">
-  The credentials and permissions OVHcloud needs, every environment variable, the API
-  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
-  never drifts from the code.
-</Card>
-
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
@@ -48,8 +42,7 @@ OVHcloud at any time and the connection stops; nothing else is affected.
 1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider ovhcloud`, following the
-   [OVHcloud reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/ovhcloud.md) for the environment it needs.
+4. Run the exporter with `--provider ovhcloud`.
 5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it

--- a/costgraph/integrations/ovhcloud.mdx
+++ b/costgraph/integrations/ovhcloud.mdx
@@ -1,0 +1,59 @@
+---
+title: OVHcloud
+description: "Bring OVHcloud cost into CostGraph, pulled by us or pushed by you"
+---
+
+OVHcloud bills monthly across every product, so spend is attributed per bill line item with Public Cloud usage carried per project.
+
+CostGraph reads OVHcloud as **FOCUS 1.2** records at a grain of bill line item.
+
+<Card title="OVHcloud reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/ovhcloud.md">
+  The credentials and permissions OVHcloud needs, every environment variable, the API
+  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
+  never drifts from the code.
+</Card>
+
+## Choose how the data reaches us
+
+<CardGroup cols={2}>
+  <Card title="CostGraph pulls it" icon="cloud-arrow-down">
+    You supply read-only credentials and we call OVHcloud once a day. Nothing to run.
+  </Card>
+  <Card title="You push it" icon="cloud-arrow-up">
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
+    Credentials never leave your infrastructure.
+  </Card>
+</CardGroup>
+
+## Let CostGraph pull
+
+1. Open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **OVHcloud**, name the connection, and enter the billing account these
+   charges belong to.
+3. Fill in the values the form asks for. It lists exactly the variables OVHcloud
+   needs, marks which are optional, and links this provider's reference for the
+   permissions each one requires.
+4. Select **Connect**.
+
+CostGraph verifies the credentials with a short fetch before saving, so a wrong
+value or a missing permission fails while you are still on the form.
+
+<Note>
+Credentials are encrypted at rest and used only to read billing data. Revoke them in
+OVHcloud at any time and the connection stops; nothing else is affected.
+</Note>
+
+## Push it yourself
+
+1. Open **Settings -> Integrations** and pick **FOCUS push**.
+2. Create the connection and copy its **Connection ID**.
+3. Create a CostGraph API key with the `focus:write` scope.
+4. Run the exporter with `--provider ovhcloud`, following the
+   [OVHcloud reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/ovhcloud.md) for the environment it needs.
+5. Send the records to CostGraph, quoting the connection id and API key.
+
+## What CostGraph does with it
+
+Records land as raw billing rows, are normalised into line items, and roll up into
+daily cost. From there OVHcloud spend appears in Cost Overview and in anomaly
+detection alongside every other provider.

--- a/costgraph/integrations/respanai.mdx
+++ b/costgraph/integrations/respanai.mdx
@@ -9,12 +9,6 @@ Formerly KeywordsAI.
 
 CostGraph reads RespanAI as **FOCUS 1.2** records at a grain of day x model x upstream provider (request spend).
 
-<Card title="RespanAI reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/respanai.md">
-  The credentials and permissions RespanAI needs, every environment variable, the API
-  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
-  never drifts from the code.
-</Card>
-
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
@@ -50,8 +44,7 @@ RespanAI at any time and the connection stops; nothing else is affected.
 1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider respanai`, following the
-   [RespanAI reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/respanai.md) for the environment it needs.
+4. Run the exporter with `--provider respanai`.
 5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it

--- a/costgraph/integrations/stackit.mdx
+++ b/costgraph/integrations/stackit.mdx
@@ -7,12 +7,6 @@ STACKIT bills per project across its managed services, so spend is attributed pe
 
 CostGraph reads STACKIT as **FOCUS 1.2** records at a grain of day x project x service.
 
-<Card title="STACKIT reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/stackit.md">
-  The credentials and permissions STACKIT needs, every environment variable, the API
-  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
-  never drifts from the code.
-</Card>
-
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
@@ -48,8 +42,7 @@ STACKIT at any time and the connection stops; nothing else is affected.
 1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider stackit`, following the
-   [STACKIT reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/stackit.md) for the environment it needs.
+4. Run the exporter with `--provider stackit`.
 5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it

--- a/costgraph/integrations/stackit.mdx
+++ b/costgraph/integrations/stackit.mdx
@@ -1,0 +1,59 @@
+---
+title: STACKIT
+description: "Bring STACKIT cost into CostGraph, pulled by us or pushed by you"
+---
+
+STACKIT bills per project across its managed services, so spend is attributed per project and service.
+
+CostGraph reads STACKIT as **FOCUS 1.2** records at a grain of day x project x service.
+
+<Card title="STACKIT reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/stackit.md">
+  The credentials and permissions STACKIT needs, every environment variable, the API
+  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
+  never drifts from the code.
+</Card>
+
+## Choose how the data reaches us
+
+<CardGroup cols={2}>
+  <Card title="CostGraph pulls it" icon="cloud-arrow-down">
+    You supply read-only credentials and we call STACKIT once a day. Nothing to run.
+  </Card>
+  <Card title="You push it" icon="cloud-arrow-up">
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
+    Credentials never leave your infrastructure.
+  </Card>
+</CardGroup>
+
+## Let CostGraph pull
+
+1. Open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **STACKIT**, name the connection, and enter the billing account these
+   charges belong to.
+3. Fill in the values the form asks for. It lists exactly the variables STACKIT
+   needs, marks which are optional, and links this provider's reference for the
+   permissions each one requires.
+4. Select **Connect**.
+
+CostGraph verifies the credentials with a short fetch before saving, so a wrong
+value or a missing permission fails while you are still on the form.
+
+<Note>
+Credentials are encrypted at rest and used only to read billing data. Revoke them in
+STACKIT at any time and the connection stops; nothing else is affected.
+</Note>
+
+## Push it yourself
+
+1. Open **Settings -> Integrations** and pick **FOCUS push**.
+2. Create the connection and copy its **Connection ID**.
+3. Create a CostGraph API key with the `focus:write` scope.
+4. Run the exporter with `--provider stackit`, following the
+   [STACKIT reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/stackit.md) for the environment it needs.
+5. Send the records to CostGraph, quoting the connection id and API key.
+
+## What CostGraph does with it
+
+Records land as raw billing rows, are normalised into line items, and roll up into
+daily cost. From there STACKIT spend appears in Cost Overview and in anomaly
+detection alongside every other provider.

--- a/costgraph/integrations/vercel.mdx
+++ b/costgraph/integrations/vercel.mdx
@@ -7,12 +7,6 @@ Vercel bills charges per project across your team, so spend is attributed per se
 
 CostGraph reads Vercel as **FOCUS 1.2** records at a grain of day x service x project.
 
-<Card title="Vercel reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/vercel.md">
-  The credentials and permissions Vercel needs, every environment variable, the API
-  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
-  never drifts from the code.
-</Card>
-
 ## Choose how the data reaches us
 
 <CardGroup cols={2}>
@@ -48,8 +42,7 @@ Vercel at any time and the connection stops; nothing else is affected.
 1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider vercel`, following the
-   [Vercel reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/vercel.md) for the environment it needs.
+4. Run the exporter with `--provider vercel`.
 5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it

--- a/costgraph/integrations/vercel.mdx
+++ b/costgraph/integrations/vercel.mdx
@@ -1,0 +1,59 @@
+---
+title: Vercel
+description: "Bring Vercel cost into CostGraph, pulled by us or pushed by you"
+---
+
+Vercel bills charges per project across your team, so spend is attributed per service and project.
+
+CostGraph reads Vercel as **FOCUS 1.2** records at a grain of day x service x project.
+
+<Card title="Vercel reference" icon="book" href="https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/vercel.md">
+  The credentials and permissions Vercel needs, every environment variable, the API
+  endpoints called, and the full FOCUS field mapping. Kept with the exporter so it
+  never drifts from the code.
+</Card>
+
+## Choose how the data reaches us
+
+<CardGroup cols={2}>
+  <Card title="CostGraph pulls it" icon="cloud-arrow-down">
+    You supply read-only credentials and we call Vercel once a day. Nothing to run.
+  </Card>
+  <Card title="You push it" icon="cloud-arrow-up">
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
+    Credentials never leave your infrastructure.
+  </Card>
+</CardGroup>
+
+## Let CostGraph pull
+
+1. Open **Settings -> Integrations** and pick **FOCUS pull**.
+2. Choose **Vercel**, name the connection, and enter the billing account these
+   charges belong to.
+3. Fill in the values the form asks for. It lists exactly the variables Vercel
+   needs, marks which are optional, and links this provider's reference for the
+   permissions each one requires.
+4. Select **Connect**.
+
+CostGraph verifies the credentials with a short fetch before saving, so a wrong
+value or a missing permission fails while you are still on the form.
+
+<Note>
+Credentials are encrypted at rest and used only to read billing data. Revoke them in
+Vercel at any time and the connection stops; nothing else is affected.
+</Note>
+
+## Push it yourself
+
+1. Open **Settings -> Integrations** and pick **FOCUS push**.
+2. Create the connection and copy its **Connection ID**.
+3. Create a CostGraph API key with the `focus:write` scope.
+4. Run the exporter with `--provider vercel`, following the
+   [Vercel reference](https://github.com/baselinehq/focus-exporter/blob/main/docs/providers/vercel.md) for the environment it needs.
+5. Send the records to CostGraph, quoting the connection id and API key.
+
+## What CostGraph does with it
+
+Records land as raw billing rows, are normalised into line items, and roll up into
+daily cost. From there Vercel spend appears in Cost Overview and in anomaly
+detection alongside every other provider.

--- a/docs.json
+++ b/docs.json
@@ -66,15 +66,22 @@
             "pages": [
               "costgraph/integrations/anthropic",
               "costgraph/integrations/aws",
+              "costgraph/integrations/cloudflare",
               "costgraph/integrations/confluent",
+              "costgraph/integrations/cursor",
+              "costgraph/integrations/digitalocean",
               "costgraph/integrations/gcp",
               "costgraph/integrations/github",
+              "costgraph/integrations/grafanacloud",
               "costgraph/integrations/helicone",
               "costgraph/integrations/modal",
               "costgraph/integrations/openai",
               "costgraph/integrations/openrouter",
+              "costgraph/integrations/ovhcloud",
               "costgraph/integrations/planetscale",
-              "costgraph/integrations/respanai"
+              "costgraph/integrations/respanai",
+              "costgraph/integrations/stackit",
+              "costgraph/integrations/vercel"
             ]
           }
         ]


### PR DESCRIPTION
Adds Integrations pages for the focus-exporter providers that had none: cloudflare, cursor, digitalocean, grafanacloud, ovhcloud, stackit, vercel. Each follows the existing integration mdx template and is registered in the docs.json Integrations nav (alphabetical).

Sources: each provider's guide in focus-exporter origin/main docs/providers/<slug>.md (stackit derived from the feat/stackit-provider branch, pending merge).

Note: page reference Cards link to docs/providers/<slug>.md on focus-exporter main; the stackit link 404s until focus-exporter #46 merges.