### PR TITLE
docs: redirect retired exporter URLs and add the CostGraph integration page

### DIFF
--- a/costgraph/integrations/anthropic.mdx
+++ b/costgraph/integrations/anthropic.mdx
@@ -14,8 +14,7 @@ CostGraph reads Anthropic as **FOCUS 1.2** records at a grain of day x model x t
     You supply read-only credentials and we call Anthropic once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
-    Credentials never leave your infrastructure.
+    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 

--- a/costgraph/integrations/anthropic.mdx
+++ b/costgraph/integrations/anthropic.mdx
@@ -20,12 +20,10 @@ CostGraph reads Anthropic as **FOCUS 1.2** records at a grain of day x model x t
 
 ## Let CostGraph pull
 
-1. Open **Settings -> Integrations** and pick **FOCUS pull**.
-2. Choose **Anthropic**, name the connection, and enter the billing account these
-   charges belong to.
+1. Open **Settings -> Integrations** and pick **Anthropic**.
+2. Name the connection and pick the tenant these charges belong to.
 3. Fill in the values the form asks for. It lists exactly the variables Anthropic
-   needs, marks which are optional, and links this provider's reference for the
-   permissions each one requires.
+   needs, marks which are optional, and explains the permission each one requires.
 4. Select **Connect**.
 
 CostGraph verifies the credentials with a short fetch before saving, so a wrong

--- a/costgraph/integrations/cloudflare.mdx
+++ b/costgraph/integrations/cloudflare.mdx
@@ -14,8 +14,7 @@ CostGraph reads Cloudflare as **FOCUS 1.2** records at a grain of day x service 
     You supply read-only credentials and we call Cloudflare once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
-    Credentials never leave your infrastructure.
+    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 

--- a/costgraph/integrations/cloudflare.mdx
+++ b/costgraph/integrations/cloudflare.mdx
@@ -21,12 +21,10 @@ CostGraph reads Cloudflare as **FOCUS 1.2** records at a grain of day x service 
 
 ## Let CostGraph pull
 
-1. Open **Settings -> Integrations** and pick **FOCUS pull**.
-2. Choose **Cloudflare**, name the connection, and enter the billing account these
-   charges belong to.
+1. Open **Settings -> Integrations** and pick **Cloudflare**.
+2. Name the connection and pick the tenant these charges belong to.
 3. Fill in the values the form asks for. It lists exactly the variables Cloudflare
-   needs, marks which are optional, and links this provider's reference for the
-   permissions each one requires.
+   needs, marks which are optional, and explains the permission each one requires.
 4. Select **Connect**.
 
 CostGraph verifies the credentials with a short fetch before saving, so a wrong

--- a/costgraph/integrations/confluent.mdx
+++ b/costgraph/integrations/confluent.mdx
@@ -14,8 +14,7 @@ CostGraph reads Confluent Cloud as **FOCUS 1.2** records at a grain of billing l
     You supply read-only credentials and we call Confluent Cloud once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
-    Credentials never leave your infrastructure.
+    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 

--- a/costgraph/integrations/confluent.mdx
+++ b/costgraph/integrations/confluent.mdx
@@ -20,12 +20,10 @@ CostGraph reads Confluent Cloud as **FOCUS 1.2** records at a grain of billing l
 
 ## Let CostGraph pull
 
-1. Open **Settings -> Integrations** and pick **FOCUS pull**.
-2. Choose **Confluent Cloud**, name the connection, and enter the billing account these
-   charges belong to.
+1. Open **Settings -> Integrations** and pick **Confluent Cloud**.
+2. Name the connection and pick the tenant these charges belong to.
 3. Fill in the values the form asks for. It lists exactly the variables Confluent Cloud
-   needs, marks which are optional, and links this provider's reference for the
-   permissions each one requires.
+   needs, marks which are optional, and explains the permission each one requires.
 4. Select **Connect**.
 
 CostGraph verifies the credentials with a short fetch before saving, so a wrong

--- a/costgraph/integrations/costgraph.mdx
+++ b/costgraph/integrations/costgraph.mdx
@@ -8,7 +8,8 @@ dataset as the infrastructure it monitors, including the account-level fees, tax
 and credits on the invoice.
 
 CostGraph reads its own billing as **FOCUS 1.2** records at a grain of billing period
-x tenant x meter, each row carrying its tenant as the FOCUS sub-account.
+x tenant x meter, each metered row carrying its tenant as the FOCUS sub-account.
+Account-level fees, taxes and credits carry none.
 
 <Note>
 Costs and charge categories come straight from the billing API and are reconciled
@@ -56,10 +57,11 @@ affected.
 
 1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
-3. Create a second CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider costgraph`, exporting the `focus:read` key as
+3. Grant that same API key the `focus:write` scope alongside `focus:read`. Reading your
+   billing and pushing it back use one key, so it needs both scopes.
+4. Run the exporter with `--provider costgraph`, exporting the key as
    `COSTGRAPH_API_KEY`.
-5. Send the records to CostGraph, quoting the connection id and the `focus:write` key.
+5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/costgraph.mdx
+++ b/costgraph/integrations/costgraph.mdx
@@ -1,0 +1,63 @@
+---
+title: CostGraph
+description: "Fold your own CostGraph invoice into the dataset it watches"
+---
+
+CostGraph bills per billing period, tenant and meter, plus the account-level fees,
+taxes and credits on the invoice. Exporting it puts what your FinOps tooling costs
+into the same dataset as the infrastructure it monitors.
+
+CostGraph reads its own billing as **FOCUS 1.2** records at a grain of billing period
+x tenant x meter, each row carrying its tenant as the FOCUS sub-account.
+
+<Note>
+The billing API already returns FOCUS records, so this adapter maps rather than
+derives. Costs, charge categories and the usage-versus-fee split are computed
+server-side and reconciled against the invoice.
+</Note>
+
+## Choose how the data reaches us
+
+<CardGroup cols={2}>
+  <Card title="CostGraph pulls it" icon="cloud-arrow-down">
+    You supply a read-only API key and we call the billing API once a day. Nothing to run.
+  </Card>
+  <Card title="You push it" icon="cloud-arrow-up">
+    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
+    Credentials never leave your infrastructure.
+  </Card>
+</CardGroup>
+
+## Create the API key
+
+1. Open **Settings -> API keys** and create a key.
+2. Grant it the **`focus:read`** scope. Nothing else is required.
+
+<Warning>
+The key must belong to an organization owner or billing admin. A key created by a
+member carries that member's role and cannot read billing data.
+</Warning>
+
+## Let CostGraph pull
+
+1. Open **Settings -> Integrations** and pick **CostGraph**.
+2. Name the connection and pick the tenant these charges belong to.
+3. Paste the API key. The base URL is optional and defaults to `https://api.costgraph.ai`.
+4. Select **Connect**.
+
+CostGraph verifies the key with a short fetch before saving, so a wrong value or a
+missing scope fails while you are still on the form.
+
+## Push it yourself
+
+1. Open **Settings -> Integrations** and pick **FOCUS push**.
+2. Create the connection and copy its **Connection ID**.
+3. Create a second CostGraph API key with the `focus:write` scope.
+4. Run the exporter with `--provider costgraph`, exporting `COSTGRAPH_API_KEY`.
+5. Send the records to CostGraph, quoting the connection id and API key.
+
+## What CostGraph does with it
+
+Records land as raw billing rows, are normalised into line items, and roll up into
+daily cost. From there your CostGraph subscription appears in Cost Overview and in
+anomaly detection alongside every other provider.

--- a/costgraph/integrations/costgraph.mdx
+++ b/costgraph/integrations/costgraph.mdx
@@ -23,8 +23,7 @@ server-side and reconciled against the invoice.
     You supply a read-only API key and we call the billing API once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
-    Credentials never leave your infrastructure.
+    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 

--- a/costgraph/integrations/costgraph.mdx
+++ b/costgraph/integrations/costgraph.mdx
@@ -30,7 +30,7 @@ server-side and reconciled against the invoice.
 ## Create the API key
 
 1. Open **Settings -> API keys** and create a key.
-2. Grant it the **`focus:read`** scope. Nothing else is required.
+2. Grant it the **`focus:read`** scope. No additional scopes are required.
 
 <Warning>
 The key must belong to an organization owner or billing admin. A key created by a
@@ -52,7 +52,9 @@ missing scope fails while you are still on the form.
 1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a second CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider costgraph`, exporting `COSTGRAPH_API_KEY`.
+4. Run the exporter with `--provider costgraph`, exporting the `focus:read` key as
+   `COSTGRAPH_API_KEY`. Pushing needs both keys: the read key to fetch your billing,
+   the write key to send it back.
 5. Send the records to CostGraph, quoting the connection id and API key.
 
 ## What CostGraph does with it

--- a/costgraph/integrations/costgraph.mdx
+++ b/costgraph/integrations/costgraph.mdx
@@ -3,17 +3,16 @@ title: CostGraph
 description: "Fold your own CostGraph invoice into the dataset it watches"
 ---
 
-CostGraph bills per billing period, tenant and meter, plus the account-level fees,
-taxes and credits on the invoice. Exporting it puts what your FinOps tooling costs
-into the same dataset as the infrastructure it monitors.
+Exporting your CostGraph invoice puts what your FinOps tooling costs into the same
+dataset as the infrastructure it monitors, including the account-level fees, taxes
+and credits on the invoice.
 
 CostGraph reads its own billing as **FOCUS 1.2** records at a grain of billing period
 x tenant x meter, each row carrying its tenant as the FOCUS sub-account.
 
 <Note>
-The billing API already returns FOCUS records, so this adapter maps rather than
-derives. Costs, charge categories and the usage-versus-fee split are computed
-server-side and reconciled against the invoice.
+Costs and charge categories come straight from the billing API and are reconciled
+against your invoice.
 </Note>
 
 ## Choose how the data reaches us
@@ -30,11 +29,11 @@ server-side and reconciled against the invoice.
 ## Create the API key
 
 1. Open **Settings -> API keys** and create a key.
-2. Grant it the **`focus:read`** scope. No additional scopes are required.
+2. Grant it the **`focus:read`** scope.
 
 <Warning>
-The key must belong to an organization owner or billing admin. A key created by a
-member carries that member's role and cannot read billing data.
+The key must belong to an organization owner or billing admin; a member's key cannot
+read billing data.
 </Warning>
 
 ## Let CostGraph pull
@@ -47,15 +46,20 @@ member carries that member's role and cannot read billing data.
 CostGraph verifies the key with a short fetch before saving, so a wrong value or a
 missing scope fails while you are still on the form.
 
+<Note>
+Credentials are encrypted at rest and used only to read billing data. Revoke the key
+in **Settings -> API keys** at any time and the connection stops; nothing else is
+affected.
+</Note>
+
 ## Push it yourself
 
 1. Open **Settings -> Integrations** and pick **FOCUS push**.
 2. Create the connection and copy its **Connection ID**.
 3. Create a second CostGraph API key with the `focus:write` scope.
 4. Run the exporter with `--provider costgraph`, exporting the `focus:read` key as
-   `COSTGRAPH_API_KEY`. Pushing needs both keys: the read key to fetch your billing,
-   the write key to send it back.
-5. Send the records to CostGraph, quoting the connection id and API key.
+   `COSTGRAPH_API_KEY`.
+5. Send the records to CostGraph, quoting the connection id and the `focus:write` key.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/cursor.mdx
+++ b/costgraph/integrations/cursor.mdx
@@ -8,8 +8,8 @@ Cursor bills team usage per model, so spend is attributed per model and per team
 CostGraph reads Cursor as **FOCUS 1.2** records at a grain of day x model x user (charged spend).
 
 <Note>
-Cursor attributes charged spend to the team member who incurred it, so member email
-addresses arrive with the records and show up as the sub-account on Cursor line items.
+Member email addresses arrive with the records and appear as the sub-account on
+Cursor line items.
 </Note>
 
 ## Choose how the data reaches us

--- a/costgraph/integrations/cursor.mdx
+++ b/costgraph/integrations/cursor.mdx
@@ -19,8 +19,7 @@ addresses arrive with the records and show up as the sub-account on Cursor line 
     You supply read-only credentials and we call Cursor once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
-    Credentials never leave your infrastructure.
+    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 

--- a/costgraph/integrations/cursor.mdx
+++ b/costgraph/integrations/cursor.mdx
@@ -3,9 +3,14 @@ title: Cursor
 description: "Bring Cursor cost into CostGraph, pulled by us or pushed by you"
 ---
 
-Cursor bills team usage per model, so spend is attributed per model across your team.
+Cursor bills team usage per model, so spend is attributed per model and per team member.
 
-CostGraph reads Cursor as **FOCUS 1.2** records at a grain of day x model (team usage events).
+CostGraph reads Cursor as **FOCUS 1.2** records at a grain of day x model x user (charged spend).
+
+<Note>
+Cursor attributes charged spend to the team member who incurred it, so member email
+addresses arrive with the records and show up as the sub-account on Cursor line items.
+</Note>
 
 ## Choose how the data reaches us
 
@@ -21,12 +26,10 @@ CostGraph reads Cursor as **FOCUS 1.2** records at a grain of day x model (team 
 
 ## Let CostGraph pull
 
-1. Open **Settings -> Integrations** and pick **FOCUS pull**.
-2. Choose **Cursor**, name the connection, and enter the billing account these
-   charges belong to.
+1. Open **Settings -> Integrations** and pick **Cursor**.
+2. Name the connection and pick the tenant these charges belong to.
 3. Fill in the values the form asks for. It lists exactly the variables Cursor
-   needs, marks which are optional, and links this provider's reference for the
-   permissions each one requires.
+   needs, marks which are optional, and explains the permission each one requires.
 4. Select **Connect**.
 
 CostGraph verifies the credentials with a short fetch before saving, so a wrong

--- a/costgraph/integrations/digitalocean.mdx
+++ b/costgraph/integrations/digitalocean.mdx
@@ -16,8 +16,7 @@ CostGraph reads DigitalOcean as **FOCUS 1.2** records at a grain of invoice line
     You supply a read-only token and we call DigitalOcean once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
-    Credentials never leave your infrastructure.
+    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 

--- a/costgraph/integrations/digitalocean.mdx
+++ b/costgraph/integrations/digitalocean.mdx
@@ -23,7 +23,7 @@ CostGraph reads DigitalOcean as **FOCUS 1.2** records at a grain of invoice line
 ## Let CostGraph pull
 
 1. Open **Settings -> Integrations** and pick **DigitalOcean**.
-2. Name the connection.
+2. Name the connection and pick the tenant these charges belong to.
 3. Create a Personal Access Token with **read** scope under **Account -> API -> Tokens**
    and paste it in.
 4. Select **Connect**.

--- a/costgraph/integrations/github.mdx
+++ b/costgraph/integrations/github.mdx
@@ -16,8 +16,7 @@ repository, carrying both gross and net billed cost.
     You supply a read-only token and we call GitHub once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
-    Credentials never leave your infrastructure.
+    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 

--- a/costgraph/integrations/github.mdx
+++ b/costgraph/integrations/github.mdx
@@ -23,7 +23,8 @@ repository, carrying both gross and net billed cost.
 ## Let CostGraph pull
 
 1. Open **Settings -> Integrations** and pick **GitHub**.
-2. Name the connection and enter the organization login whose billing you want.
+2. Name the connection, pick the tenant these charges belong to, and enter the
+   organization login whose billing you want.
 3. Supply a token with read access to the organization's billing. A fine-grained
    personal access token needs **Administration: read**; a classic token needs the
    billing read scope.

--- a/costgraph/integrations/grafanacloud.mdx
+++ b/costgraph/integrations/grafanacloud.mdx
@@ -18,8 +18,7 @@ organization-level row.
     You supply a read-only token and we call Grafana Cloud once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
-    Credentials never leave your infrastructure.
+    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 

--- a/costgraph/integrations/grafanacloud.mdx
+++ b/costgraph/integrations/grafanacloud.mdx
@@ -25,8 +25,8 @@ organization-level row.
 ## Let CostGraph pull
 
 1. Open **Settings -> Integrations** and pick **Grafana Cloud**.
-2. Name the connection and enter your organization slug, the `{org}` in
-   `grafana.com/orgs/{org}`.
+2. Name the connection, pick the tenant these charges belong to, and enter your
+   organization slug, the `{org}` in `grafana.com/orgs/{org}`.
 3. Create an **Access Policy token** whose realm is the organization, carrying the
    billing read scopes: `billing-metrics:read`, `org-billing-info:read`,
    `org-billing-rate:read`, `invoices:read` and `orgs:read`. Paste it in.

--- a/costgraph/integrations/helicone.mdx
+++ b/costgraph/integrations/helicone.mdx
@@ -20,12 +20,10 @@ CostGraph reads Helicone as **FOCUS 1.2** records at a grain of day x model x up
 
 ## Let CostGraph pull
 
-1. Open **Settings -> Integrations** and pick **FOCUS pull**.
-2. Choose **Helicone**, name the connection, and enter the billing account these
-   charges belong to.
+1. Open **Settings -> Integrations** and pick **Helicone**.
+2. Name the connection and pick the tenant these charges belong to.
 3. Fill in the values the form asks for. It lists exactly the variables Helicone
-   needs, marks which are optional, and links this provider's reference for the
-   permissions each one requires.
+   needs, marks which are optional, and explains the permission each one requires.
 4. Select **Connect**.
 
 CostGraph verifies the credentials with a short fetch before saving, so a wrong

--- a/costgraph/integrations/helicone.mdx
+++ b/costgraph/integrations/helicone.mdx
@@ -14,8 +14,7 @@ CostGraph reads Helicone as **FOCUS 1.2** records at a grain of day x model x up
     You supply read-only credentials and we call Helicone once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
-    Credentials never leave your infrastructure.
+    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 

--- a/costgraph/integrations/modal.mdx
+++ b/costgraph/integrations/modal.mdx
@@ -14,8 +14,7 @@ CostGraph reads Modal as **FOCUS 1.2** records at a grain of day x object (per-r
     You supply read-only credentials and we call Modal once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
-    Credentials never leave your infrastructure.
+    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 

--- a/costgraph/integrations/modal.mdx
+++ b/costgraph/integrations/modal.mdx
@@ -20,12 +20,10 @@ CostGraph reads Modal as **FOCUS 1.2** records at a grain of day x object (per-r
 
 ## Let CostGraph pull
 
-1. Open **Settings -> Integrations** and pick **FOCUS pull**.
-2. Choose **Modal**, name the connection, and enter the billing account these
-   charges belong to.
+1. Open **Settings -> Integrations** and pick **Modal**.
+2. Name the connection and pick the tenant these charges belong to.
 3. Fill in the values the form asks for. It lists exactly the variables Modal
-   needs, marks which are optional, and links this provider's reference for the
-   permissions each one requires.
+   needs, marks which are optional, and explains the permission each one requires.
 4. Select **Connect**.
 
 CostGraph verifies the credentials with a short fetch before saving, so a wrong

--- a/costgraph/integrations/openai.mdx
+++ b/costgraph/integrations/openai.mdx
@@ -20,12 +20,10 @@ CostGraph reads OpenAI as **FOCUS 1.2** records at a grain of day x model x toke
 
 ## Let CostGraph pull
 
-1. Open **Settings -> Integrations** and pick **FOCUS pull**.
-2. Choose **OpenAI**, name the connection, and enter the billing account these
-   charges belong to.
+1. Open **Settings -> Integrations** and pick **OpenAI**.
+2. Name the connection and pick the tenant these charges belong to.
 3. Fill in the values the form asks for. It lists exactly the variables OpenAI
-   needs, marks which are optional, and links this provider's reference for the
-   permissions each one requires.
+   needs, marks which are optional, and explains the permission each one requires.
 4. Select **Connect**.
 
 CostGraph verifies the credentials with a short fetch before saving, so a wrong

--- a/costgraph/integrations/openai.mdx
+++ b/costgraph/integrations/openai.mdx
@@ -14,8 +14,7 @@ CostGraph reads OpenAI as **FOCUS 1.2** records at a grain of day x model x toke
     You supply read-only credentials and we call OpenAI once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
-    Credentials never leave your infrastructure.
+    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 

--- a/costgraph/integrations/openrouter.mdx
+++ b/costgraph/integrations/openrouter.mdx
@@ -14,8 +14,7 @@ CostGraph reads OpenRouter as **FOCUS 1.2** records at a grain of day x model x 
     You supply read-only credentials and we call OpenRouter once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
-    Credentials never leave your infrastructure.
+    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 

--- a/costgraph/integrations/openrouter.mdx
+++ b/costgraph/integrations/openrouter.mdx
@@ -20,12 +20,10 @@ CostGraph reads OpenRouter as **FOCUS 1.2** records at a grain of day x model x 
 
 ## Let CostGraph pull
 
-1. Open **Settings -> Integrations** and pick **FOCUS pull**.
-2. Choose **OpenRouter**, name the connection, and enter the billing account these
-   charges belong to.
+1. Open **Settings -> Integrations** and pick **OpenRouter**.
+2. Name the connection and pick the tenant these charges belong to.
 3. Fill in the values the form asks for. It lists exactly the variables OpenRouter
-   needs, marks which are optional, and links this provider's reference for the
-   permissions each one requires.
+   needs, marks which are optional, and explains the permission each one requires.
 4. Select **Connect**.
 
 CostGraph verifies the credentials with a short fetch before saving, so a wrong

--- a/costgraph/integrations/ovhcloud.mdx
+++ b/costgraph/integrations/ovhcloud.mdx
@@ -21,12 +21,11 @@ CostGraph reads OVHcloud as **FOCUS 1.2** records at a grain of bill line item.
 
 ## Let CostGraph pull
 
-1. Open **Settings -> Integrations** and pick **FOCUS pull**.
-2. Choose **OVHcloud**, name the connection, and enter the billing account these
-   charges belong to.
+1. Open **Settings -> Integrations** and pick **OVHcloud**.
+2. Name the connection and pick the tenant these charges belong to.
 3. Fill in the values the form asks for. It lists exactly the variables OVHcloud
-   needs, marks which are optional, and links this provider's reference for the
-   permissions each one requires.
+   needs, marks which are optional, and explains the permission each one requires.
+   The client id carries the API region as its prefix (`EU.`, `CA.` or `US.`).
 4. Select **Connect**.
 
 CostGraph verifies the credentials with a short fetch before saving, so a wrong

--- a/costgraph/integrations/ovhcloud.mdx
+++ b/costgraph/integrations/ovhcloud.mdx
@@ -14,8 +14,7 @@ CostGraph reads OVHcloud as **FOCUS 1.2** records at a grain of bill line item.
     You supply read-only credentials and we call OVHcloud once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
-    Credentials never leave your infrastructure.
+    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 

--- a/costgraph/integrations/respanai.mdx
+++ b/costgraph/integrations/respanai.mdx
@@ -16,8 +16,7 @@ CostGraph reads RespanAI as **FOCUS 1.2** records at a grain of day x model x up
     You supply read-only credentials and we call RespanAI once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
-    Credentials never leave your infrastructure.
+    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 

--- a/costgraph/integrations/respanai.mdx
+++ b/costgraph/integrations/respanai.mdx
@@ -22,12 +22,10 @@ CostGraph reads RespanAI as **FOCUS 1.2** records at a grain of day x model x up
 
 ## Let CostGraph pull
 
-1. Open **Settings -> Integrations** and pick **FOCUS pull**.
-2. Choose **RespanAI**, name the connection, and enter the billing account these
-   charges belong to.
+1. Open **Settings -> Integrations** and pick **RespanAI**.
+2. Name the connection and pick the tenant these charges belong to.
 3. Fill in the values the form asks for. It lists exactly the variables RespanAI
-   needs, marks which are optional, and links this provider's reference for the
-   permissions each one requires.
+   needs, marks which are optional, and explains the permission each one requires.
 4. Select **Connect**.
 
 CostGraph verifies the credentials with a short fetch before saving, so a wrong

--- a/costgraph/integrations/stackit.mdx
+++ b/costgraph/integrations/stackit.mdx
@@ -26,10 +26,12 @@ CostGraph reads STACKIT as **FOCUS 1.2** records at a grain of day x project x s
    needs, marks which are optional, and explains the permission each one requires.
 4. Select **Connect**.
 
-The service account key is offered as a value or a file path, and the private key
-only when the key JSON carries no embedded one, so both pairs are marked optional.
-Supply one of each pair: a connection with neither key fails verification. The
-service account needs the `cost-management.cost.reader` role on the customer
+The service account key JSON is always required, as a value or a file path. Whether
+you also need the private key depends on how the key was made: a key STACKIT
+generated carries `credentials.privateKey` inside the JSON and needs nothing more,
+while a key created from a public key you uploaded has no embedded private key, so
+supply the PEM-encoded one alongside it. Given both, the separate private key wins.
+The service account needs the `cost-management.cost.reader` role on the customer
 account you export.
 
 CostGraph verifies the credentials with a short fetch before saving, so a wrong

--- a/costgraph/integrations/stackit.mdx
+++ b/costgraph/integrations/stackit.mdx
@@ -21,13 +21,17 @@ CostGraph reads STACKIT as **FOCUS 1.2** records at a grain of day x project x s
 
 ## Let CostGraph pull
 
-1. Open **Settings -> Integrations** and pick **FOCUS pull**.
-2. Choose **STACKIT**, name the connection, and enter the billing account these
-   charges belong to.
+1. Open **Settings -> Integrations** and pick **STACKIT**.
+2. Name the connection and pick the tenant these charges belong to.
 3. Fill in the values the form asks for. It lists exactly the variables STACKIT
-   needs, marks which are optional, and links this provider's reference for the
-   permissions each one requires.
+   needs, marks which are optional, and explains the permission each one requires.
 4. Select **Connect**.
+
+The service account key is offered as a value or a file path, and the private key
+only when the key JSON carries no embedded one, so both pairs are marked optional.
+Supply one of each pair: a connection with neither key fails verification. The
+service account needs the `cost-management.cost.reader` role on the customer
+account you export.
 
 CostGraph verifies the credentials with a short fetch before saving, so a wrong
 value or a missing permission fails while you are still on the form.

--- a/costgraph/integrations/stackit.mdx
+++ b/costgraph/integrations/stackit.mdx
@@ -14,8 +14,7 @@ CostGraph reads STACKIT as **FOCUS 1.2** records at a grain of day x project x s
     You supply read-only credentials and we call STACKIT once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
-    Credentials never leave your infrastructure.
+    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 

--- a/costgraph/integrations/stackit.mdx
+++ b/costgraph/integrations/stackit.mdx
@@ -26,11 +26,11 @@ CostGraph reads STACKIT as **FOCUS 1.2** records at a grain of day x project x s
    needs, marks which are optional, and explains the permission each one requires.
 4. Select **Connect**.
 
-The service account key JSON is always required, as a value or a file path. Whether
-you also need the private key depends on how the key was made: a key STACKIT
-generated carries `credentials.privateKey` inside the JSON and needs nothing more,
-while a key created from a public key you uploaded has no embedded private key, so
-supply the PEM-encoded one alongside it. Given both, the separate private key wins.
+The service account key JSON is always required, as a value or a file path. If you
+created the key from a public key you uploaded, also supply the PEM-encoded private
+key; keys STACKIT generated already embed it. Given both, the separate private key
+wins.
+
 The service account needs the `cost-management.cost.reader` role on the customer
 account you export.
 

--- a/costgraph/integrations/vercel.mdx
+++ b/costgraph/integrations/vercel.mdx
@@ -21,12 +21,11 @@ CostGraph reads Vercel as **FOCUS 1.2** records at a grain of day x service x pr
 
 ## Let CostGraph pull
 
-1. Open **Settings -> Integrations** and pick **FOCUS pull**.
-2. Choose **Vercel**, name the connection, and enter the billing account these
-   charges belong to.
+1. Open **Settings -> Integrations** and pick **Vercel**.
+2. Name the connection and pick the tenant these charges belong to.
 3. Fill in the values the form asks for. It lists exactly the variables Vercel
-   needs, marks which are optional, and links this provider's reference for the
-   permissions each one requires.
+   needs, marks which are optional, and explains the permission each one requires.
+   The team is optional: when the token sees exactly one team we resolve it for you.
 4. Select **Connect**.
 
 CostGraph verifies the credentials with a short fetch before saving, so a wrong

--- a/costgraph/integrations/vercel.mdx
+++ b/costgraph/integrations/vercel.mdx
@@ -14,8 +14,7 @@ CostGraph reads Vercel as **FOCUS 1.2** records at a grain of day x service x pr
     You supply read-only credentials and we call Vercel once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run [focus-exporter](https://github.com/baselinehq/focus-exporter) yourself.
-    Credentials never leave your infrastructure.
+    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 

--- a/docs.json
+++ b/docs.json
@@ -276,12 +276,24 @@
       "destination": "/costgraph/integrations/openrouter"
     },
     {
+      "source": "/costgraph/focus-exporter/ovhcloud",
+      "destination": "/costgraph/integrations/ovhcloud"
+    },
+    {
       "source": "/costgraph/focus-exporter/planetscale",
       "destination": "/costgraph/integrations/planetscale"
     },
     {
       "source": "/costgraph/focus-exporter/respanai",
       "destination": "/costgraph/integrations/respanai"
+    },
+    {
+      "source": "/costgraph/focus-exporter/stackit",
+      "destination": "/costgraph/integrations/stackit"
+    },
+    {
+      "source": "/costgraph/focus-exporter/vercel",
+      "destination": "/costgraph/integrations/vercel"
     }
   ],
   "contextual": {

--- a/docs.json
+++ b/docs.json
@@ -68,6 +68,7 @@
               "costgraph/integrations/aws",
               "costgraph/integrations/cloudflare",
               "costgraph/integrations/confluent",
+              "costgraph/integrations/costgraph",
               "costgraph/integrations/cursor",
               "costgraph/integrations/digitalocean",
               "costgraph/integrations/gcp",
@@ -225,6 +226,10 @@
     {
       "source": "/costgraph/recommendations",
       "destination": "/costgraph/agent/recommendations"
+    },
+    {
+      "source": "/costgraph/focus-exporter/:slug",
+      "destination": "/costgraph/integrations/:slug"
     }
   ],
   "contextual": {

--- a/docs.json
+++ b/docs.json
@@ -228,8 +228,52 @@
       "destination": "/costgraph/agent/recommendations"
     },
     {
-      "source": "/costgraph/focus-exporter/:slug",
-      "destination": "/costgraph/integrations/:slug"
+      "source": "/costgraph/focus-exporter/anthropic",
+      "destination": "/costgraph/integrations/anthropic"
+    },
+    {
+      "source": "/costgraph/focus-exporter/cloudflare",
+      "destination": "/costgraph/integrations/cloudflare"
+    },
+    {
+      "source": "/costgraph/focus-exporter/confluent",
+      "destination": "/costgraph/integrations/confluent"
+    },
+    {
+      "source": "/costgraph/focus-exporter/digitalocean",
+      "destination": "/costgraph/integrations/digitalocean"
+    },
+    {
+      "source": "/costgraph/focus-exporter/github",
+      "destination": "/costgraph/integrations/github"
+    },
+    {
+      "source": "/costgraph/focus-exporter/grafanacloud",
+      "destination": "/costgraph/integrations/grafanacloud"
+    },
+    {
+      "source": "/costgraph/focus-exporter/helicone",
+      "destination": "/costgraph/integrations/helicone"
+    },
+    {
+      "source": "/costgraph/focus-exporter/modal",
+      "destination": "/costgraph/integrations/modal"
+    },
+    {
+      "source": "/costgraph/focus-exporter/openai",
+      "destination": "/costgraph/integrations/openai"
+    },
+    {
+      "source": "/costgraph/focus-exporter/openrouter",
+      "destination": "/costgraph/integrations/openrouter"
+    },
+    {
+      "source": "/costgraph/focus-exporter/planetscale",
+      "destination": "/costgraph/integrations/planetscale"
+    },
+    {
+      "source": "/costgraph/focus-exporter/respanai",
+      "destination": "/costgraph/integrations/respanai"
     }
   ],
   "contextual": {

--- a/docs.json
+++ b/docs.json
@@ -240,6 +240,14 @@
       "destination": "/costgraph/integrations/confluent"
     },
     {
+      "source": "/costgraph/focus-exporter/costgraph",
+      "destination": "/costgraph/integrations/costgraph"
+    },
+    {
+      "source": "/costgraph/focus-exporter/cursor",
+      "destination": "/costgraph/integrations/cursor"
+    },
+    {
       "source": "/costgraph/focus-exporter/digitalocean",
       "destination": "/costgraph/integrations/digitalocean"
     },


### PR DESCRIPTION
The redirect commit from #52 was pushed after that PR merged, so it never landed: all 14 retired `/costgraph/focus-exporter/*` URLs 404 today. A single wildcard rule replaces the 11 per-page entries.

focus-exporter #47 now derives every provider's `DocsURL` from `docs.costgraph.ai/costgraph/integrations/<slug>`. Every slug had a page except `costgraph`, and `docs.json` already listed `costgraph/integrations/costgraph` in the nav without the file existing. This adds the page.

Also corrects the onboarding steps on five provider pages: the connector is picked by name rather than via a generic FOCUS pull entry, and the form asks for a tenant, not a billing account. Cursor gains its per-user grain, STACKIT the key-pair and role requirements.

Claims were checked against the adapters: `COSTGRAPH_API_KEY`/`COSTGRAPH_URL` and the `https://api.costgraph.ai` default, `focus:read`, Cursor's `SetSubAccount`, STACKIT's `cost-management.cost.reader`.

`/costgraph/focus-exporter/overview` and `/sinks` redirect to integration pages that do not exist, so they stay 404 - there is no integrations index to send them to.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive CostGraph integration documentation, including FOCUS 1.2 billing records, ingestion options, API keys, validation, exporting, and reporting.
  * Added CostGraph to the Integrations navigation.
  * Added a redirect for legacy FOCUS exporter links.

* **Documentation**
  * Clarified setup instructions for Cloudflare, Cursor, OVHcloud, STACKIT, and Vercel.
  * Added guidance on tenants, credentials, permissions, regional requirements, team attribution, and optional configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->