### PR TITLE
Add Scaleway integration page

### DIFF
--- a/costgraph/integrations/scaleway.mdx
+++ b/costgraph/integrations/scaleway.mdx
@@ -1,0 +1,51 @@
+---
+title: Scaleway
+description: "Bring Scaleway cost into CostGraph, pulled by us or pushed by you"
+---
+
+Scaleway bills per-resource charges across your projects, so spend is attributed per project and resource.
+
+CostGraph reads Scaleway as **FOCUS 1.2** records at a grain of day x project x SKU x resource.
+
+## Choose how the data reaches us
+
+<CardGroup cols={2}>
+  <Card title="CostGraph pulls it" icon="cloud-arrow-down">
+    You supply read-only credentials and we call Scaleway once a day. Nothing to run.
+  </Card>
+  <Card title="You push it" icon="cloud-arrow-up">
+    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
+  </Card>
+</CardGroup>
+
+## Let CostGraph pull
+
+1. Open **Settings -> Integrations** and pick **Scaleway**.
+2. Name the connection and pick the tenant these charges belong to.
+3. Fill in the values the form asks for. It lists exactly the variables Scaleway
+   needs, marks which are optional, and explains the permission each one requires.
+   You need an IAM API key secret key with billing read access; the organization
+   is optional when you supply the key's access key, since we resolve it for you.
+4. Select **Connect**.
+
+CostGraph verifies the credentials with a short fetch before saving, so a wrong
+value or a missing permission fails while you are still on the form.
+
+<Note>
+Credentials are encrypted at rest and used only to read billing data. Revoke the
+API key in Scaleway at any time and the connection stops; nothing else is affected.
+</Note>
+
+## Push it yourself
+
+1. Open **Settings -> Integrations** and pick **FOCUS push**.
+2. Create the connection and copy its **Connection ID**.
+3. Create a CostGraph API key with the `focus:write` scope.
+4. Run the exporter with `--provider scaleway`.
+5. Send the records to CostGraph, quoting the connection id and API key.
+
+## What CostGraph does with it
+
+Records land as raw billing rows, are normalised into line items, and roll up into
+daily cost. From there Scaleway spend appears in Cost Overview and in anomaly
+detection alongside every other provider.

--- a/docs.json
+++ b/docs.json
@@ -81,6 +81,7 @@
               "costgraph/integrations/ovhcloud",
               "costgraph/integrations/planetscale",
               "costgraph/integrations/respanai",
+              "costgraph/integrations/scaleway",
               "costgraph/integrations/stackit",
               "costgraph/integrations/vercel"
             ]
@@ -286,6 +287,10 @@
     {
       "source": "/costgraph/focus-exporter/respanai",
       "destination": "/costgraph/integrations/respanai"
+    },
+    {
+      "source": "/costgraph/focus-exporter/scaleway",
+      "destination": "/costgraph/integrations/scaleway"
     },
     {
       "source": "/costgraph/focus-exporter/stackit",


### PR DESCRIPTION
Adds the public Scaleway integration doc (`costgraph/integrations/scaleway.mdx`), mirroring the other provider pages: pull (managed read-only credentials) or push (self-run exporter, `--provider scaleway`). Registers it in the Integrations nav and adds the `/costgraph/focus-exporter/scaleway` redirect.

Pairs with the exporter adapter in baselinehq/focus-exporter#48.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for integrating Scaleway with CostGraph.
  * Explained pull-based ingestion using read-only credentials and push-based ingestion through the exporter.
  * Documented data validation, normalization, reporting, daily rollups, and anomaly detection.
  * Added Scaleway to the integrations navigation.
  * Added a redirect from the legacy Scaleway exporter documentation path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->