### PR TITLE
docs: update agent changelog

### DIFF
--- a/costgraph/agent/changelog.mdx
+++ b/costgraph/agent/changelog.mdx
@@ -3,13 +3,17 @@ title: Changelogs
 description: "Release history for the CostGraph Agent"
 ---
 
-<Update label="2026-08-11" description="costgraph-operator v1.2.2">
-    ### Breaking Changes
-    - N/A
+<Update label="2026-08-13" description="v1.3.1">
+  - Auto-detect host cgroup filesystem path, no longer configurable via cli flag.
+</Update>
 
-    ### Updates
-    - Extended the agent to include root-priveleged BPF network-flow tracing that runs on compatible nodes across the fleet. Compatible nodes must expose a host-mounted cgroup v2 filesystem and run a BTF-enabled kernel for the fentry programs.
-    - Added default host filesystem mounts for `/proc` (`/host/proc`) and the host cgroup v2 filesystem `/sys/fs/cgroup`(`/host/sys/fs/cgroup`)
+<Update label="2026-08-13" description="v1.3.0">
+  Hosts without cloud provider metadata simply log a warning, instead of exit on boot. Registration fills the unresolved fields with fallbacks.
+</Update>
+
+<Update label="2026-08-11" description="v1.2.2">
+  - Extended the agent to include root-priveleged BPF network-flow tracing that runs on compatible nodes across the fleet. Compatible nodes must expose a host-mounted cgroup v2 filesystem and run a BTF-enabled kernel for the fentry programs.
+  - Added default host filesystem mounts for `/proc` (`/host/proc`) and the host cgroup v2 filesystem `/sys/fs/cgroup`(`/host/sys/fs/cgroup`).
 </Update>
 
 <Update label="2026-06-29" description="v1.0.0">

--- a/costgraph/agent/changelog.mdx
+++ b/costgraph/agent/changelog.mdx
@@ -8,12 +8,12 @@ description: "Release history for the CostGraph Agent"
 </Update>
 
 <Update label="2026-08-13" description="v1.3.0">
-  - Hosts without cloud provider metadata simply log a warning, instead of exit on boot. Registration fills the unresolved fields with fallbacks.
+  - Hosts without cloud provider metadata simply log a warning, instead of exiting on boot. Registration fills the unresolved fields with fallbacks.
 </Update>
 
 <Update label="2026-08-11" description="v1.2.2">
-  - Extended the agent to include root-priveleged BPF network-flow tracing that runs on compatible nodes across the fleet. Compatible nodes must expose a host-mounted cgroup v2 filesystem and run a BTF-enabled kernel for the fentry programs.
-  - Added default host filesystem mounts for `/proc` (`/host/proc`) and the host cgroup v2 filesystem `/sys/fs/cgroup`(`/host/sys/fs/cgroup`).
+  - Extended the agent to include root-privileged BPF network-flow tracing that runs on compatible nodes across the fleet. Compatible nodes must expose a host-mounted cgroup v2 filesystem and run a BTF-enabled kernel for the fentry programs.
+  - Added default host filesystem mounts for `/proc:/host/proc` and the host cgroup v2 filesystem `/sys/fs/cgroup:/host/sys/fs/cgroup`.
 </Update>
 
 <Update label="2026-06-29" description="v1.0.0">

--- a/costgraph/agent/changelog.mdx
+++ b/costgraph/agent/changelog.mdx
@@ -8,7 +8,7 @@ description: "Release history for the CostGraph Agent"
 </Update>
 
 <Update label="2026-08-13" description="v1.3.0">
-  Hosts without cloud provider metadata simply log a warning, instead of exit on boot. Registration fills the unresolved fields with fallbacks.
+  - Hosts without cloud provider metadata simply log a warning, instead of exit on boot. Registration fills the unresolved fields with fallbacks.
 </Update>
 
 <Update label="2026-08-11" description="v1.2.2">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added release notes for CostGraph Agent versions 1.3.1 and 1.3.0.
  - Documented automatic cgroup path detection in version 1.3.1.
  - Documented fallback registration for hosts without cloud metadata in version 1.3.0.
  - Updated the version 1.2.2 entry to clarify the agent’s BPF tracing and host-mount improvements.
  - Streamlined the version 1.2.2 changelog by removing outdated breaking-change and update sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->