### PR TITLE
Document pushing FOCUS data over the API

### DIFF
--- a/costgraph/integrations/anthropic.mdx
+++ b/costgraph/integrations/anthropic.mdx
@@ -14,7 +14,7 @@ CostGraph reads Anthropic as **FOCUS 1.2** records at a grain of day x model x t
     You supply read-only credentials and we call Anthropic once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
+    You send us FOCUS records over the API. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
@@ -36,11 +36,8 @@ Anthropic at any time and the connection stops; nothing else is affected.
 
 ## Push it yourself
 
-1. Open **Settings -> Integrations** and pick **FOCUS push**.
-2. Create the connection and copy its **Connection ID**.
-3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider anthropic`.
-5. Send the records to CostGraph, quoting the connection id and API key.
+Send the charges to CostGraph as FOCUS records instead. [Push FOCUS data](/costgraph/integrations/focus-push) covers the connection id,
+the `focus:write` key, and the request shape.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/cloudflare.mdx
+++ b/costgraph/integrations/cloudflare.mdx
@@ -14,7 +14,7 @@ CostGraph reads Cloudflare as **FOCUS 1.2** records at a grain of day x service 
     You supply read-only credentials and we call Cloudflare once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
+    You send us FOCUS records over the API. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
@@ -36,11 +36,8 @@ Cloudflare at any time and the connection stops; nothing else is affected.
 
 ## Push it yourself
 
-1. Open **Settings -> Integrations** and pick **FOCUS push**.
-2. Create the connection and copy its **Connection ID**.
-3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider cloudflare`.
-5. Send the records to CostGraph, quoting the connection id and API key.
+Send the charges to CostGraph as FOCUS records instead. [Push FOCUS data](/costgraph/integrations/focus-push) covers the connection id,
+the `focus:write` key, and the request shape.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/confluent.mdx
+++ b/costgraph/integrations/confluent.mdx
@@ -14,7 +14,7 @@ CostGraph reads Confluent Cloud as **FOCUS 1.2** records at a grain of billing l
     You supply read-only credentials and we call Confluent Cloud once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
+    You send us FOCUS records over the API. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
@@ -36,11 +36,8 @@ Confluent Cloud at any time and the connection stops; nothing else is affected.
 
 ## Push it yourself
 
-1. Open **Settings -> Integrations** and pick **FOCUS push**.
-2. Create the connection and copy its **Connection ID**.
-3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider confluent`.
-5. Send the records to CostGraph, quoting the connection id and API key.
+Send the charges to CostGraph as FOCUS records instead. [Push FOCUS data](/costgraph/integrations/focus-push) covers the connection id,
+the `focus:write` key, and the request shape.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/costgraph.mdx
+++ b/costgraph/integrations/costgraph.mdx
@@ -23,7 +23,7 @@ against your invoice.
     You supply a read-only API key and we call the billing API once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
+    You send us FOCUS records over the API. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
@@ -55,13 +55,8 @@ affected.
 
 ## Push it yourself
 
-1. Open **Settings -> Integrations** and pick **FOCUS push**.
-2. Create the connection and copy its **Connection ID**.
-3. Grant that same API key the `focus:write` scope alongside `focus:read`. Reading your
-   billing and pushing it back use one key, so it needs both scopes.
-4. Run the exporter with `--provider costgraph`, exporting the key as
-   `COSTGRAPH_API_KEY`.
-5. Send the records to CostGraph, quoting the connection id and API key.
+Send the charges to CostGraph as FOCUS records instead. [Push FOCUS data](/costgraph/integrations/focus-push) covers the connection id,
+the `focus:write` key, and the request shape.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/cursor.mdx
+++ b/costgraph/integrations/cursor.mdx
@@ -19,7 +19,7 @@ Cursor line items.
     You supply read-only credentials and we call Cursor once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
+    You send us FOCUS records over the API. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
@@ -41,11 +41,8 @@ Cursor at any time and the connection stops; nothing else is affected.
 
 ## Push it yourself
 
-1. Open **Settings -> Integrations** and pick **FOCUS push**.
-2. Create the connection and copy its **Connection ID**.
-3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider cursor`.
-5. Send the records to CostGraph, quoting the connection id and API key.
+Send the charges to CostGraph as FOCUS records instead. [Push FOCUS data](/costgraph/integrations/focus-push) covers the connection id,
+the `focus:write` key, and the request shape.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/digitalocean.mdx
+++ b/costgraph/integrations/digitalocean.mdx
@@ -16,7 +16,7 @@ CostGraph reads DigitalOcean as **FOCUS 1.2** records at a grain of invoice line
     You supply a read-only token and we call DigitalOcean once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
+    You send us FOCUS records over the API. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
@@ -43,11 +43,8 @@ in DigitalOcean at any time and the connection stops; nothing else is affected.
 
 ## Push it yourself
 
-1. Open **Settings -> Integrations** and pick **FOCUS push**.
-2. Create the connection and copy its **Connection ID**.
-3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider digitalocean`.
-5. Send the records to CostGraph, quoting the connection id and API key.
+Send the charges to CostGraph as FOCUS records instead. [Push FOCUS data](/costgraph/integrations/focus-push) covers the connection id,
+the `focus:write` key, and the request shape.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/focus-push.mdx
+++ b/costgraph/integrations/focus-push.mdx
@@ -1,0 +1,126 @@
+---
+title: Push FOCUS data
+description: "Send your own FOCUS billing records to CostGraph over the API"
+---
+
+Most integrations are **pull**: you hand CostGraph a read-only credential and it
+fetches your bill once a day. **Push** is the other direction. You send
+[FOCUS 1.2](https://focus.finops.org) records to our API yourself, and no vendor
+credential ever leaves your infrastructure.
+
+Use it for billing data CostGraph cannot reach: an internal chargeback system, a
+data warehouse job, a vendor whose export you already normalise, or a private cloud
+nobody else bills for. Whatever you send lands beside every other provider in Cost
+Overview, anomaly detection, and the MCP tools.
+
+## Create the connection
+
+1. Open **Settings -> Integrations** and choose **FOCUS push**.
+2. Pick the tenant the charges belong to and name the connection.
+3. Copy the **connection id**. It looks like `fpc_...` and identifies this stream.
+
+A connection is created in push mode and stays that way. Posting to a connection
+CostGraph syncs itself is refused with a `409`.
+
+## Create the API key
+
+1. Open **Settings -> API keys** and create a key.
+2. Grant it the **`focus:write`** scope. Nothing else is required.
+
+<Warning>
+Install tokens are rejected on this endpoint. Use an ordinary API key.
+</Warning>
+
+## Send the records
+
+```bash
+curl -X POST https://api.costgraph.ai/api/v1/tenant/billing/focus \
+  -H "Authorization: Bearer $COSTGRAPH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "connection_id": "fpc_...",
+    "complete": true,
+    "focus_version": "1.2",
+    "charge_period_start": "2026-07-01T00:00:00Z",
+    "charge_period_end": "2026-08-01T00:00:00Z",
+    "rows": [
+      {
+        "BillingAccountId": "acct-1",
+        "ChargePeriodStart": "2026-07-01T00:00:00Z",
+        "ChargePeriodEnd": "2026-07-02T00:00:00Z",
+        "ChargeCategory": "Usage",
+        "BilledCost": 12.5,
+        "EffectiveCost": 12.5,
+        "BillingCurrency": "USD",
+        "ServiceName": "Internal Platform",
+        "ProviderName": "acme",
+        "ResourceId": "svc-42"
+      }
+    ]
+  }'
+```
+
+Rows are FOCUS 1.2 records. Every row is validated, and a row that fails validation
+rejects the whole batch, so nothing lands half-applied.
+
+## The window and the `complete` flag
+
+Each push declares the charge period it covers, and what you are claiming about it.
+
+| Field | Meaning |
+|-------|---------|
+| `charge_period_start` / `charge_period_end` | The window this batch describes. End must be after start, and the window must not exceed 366 days. |
+| `complete` | `true` replaces the window. `false` (or omitted) appends to it. |
+| `focus_version` | The FOCUS version the rows conform to, for example `1.2`. |
+
+`complete: true` deletes everything previously ingested for that connection inside
+the window and replaces it with this batch. That is what makes re-sending a month
+idempotent, and it is how you correct a restatement: send the corrected month again.
+
+<Warning>
+`complete: true` with an empty `rows` array is refused, because it would silently
+delete the window. Omit `complete` if you mean to append nothing.
+</Warning>
+
+Every row's `ChargePeriodStart` must fall inside the declared window, and all rows in
+a batch must carry the same provider. The first push sets the connection's provider;
+later pushes must agree with it.
+
+## Batch size
+
+The endpoint accepts **32 MB** per request by default. A larger payload is rejected
+with a `413` telling you to split the batch. Narrow the window rather than dropping
+rows - a month is usually the natural unit.
+
+Only one ingest runs per connection at a time. A concurrent push gets a `409`, so
+retry rather than posting two batches to one connection in parallel.
+
+## A daily loop
+
+Send yesterday once the day closes, with `complete: true` so a re-run is harmless:
+
+```
+POST window [yesterday 00:00Z, today 00:00Z)  complete: true
+```
+
+Then re-send the whole month after your own books close, again with `complete: true`.
+The month replaces the days it covers, so late charges and restatements correct
+themselves without any deletion on your side.
+
+## What CostGraph does with it
+
+Records land as raw billing rows, are normalised into line items, then roll up into
+daily cost and reconcile against the invoice totals for each month the window
+touches.
+
+## Responses
+
+| Status | Meaning |
+|--------|---------|
+| `200` | Ingested. The body echoes the connection id, provider, row count, and whether the batch was complete. |
+| `400` | Malformed payload, or the window or rows failed validation. |
+| `403` | The key is missing the `focus:write` scope. |
+| `404` | No such connection for this organization and tenant. |
+| `409` | The connection is pull-mode, or another ingest is already running. |
+| `413` | Payload above the size limit. Split the batch. |
+| `422` | A row is not valid FOCUS. The message names the row index. |

--- a/costgraph/integrations/focus-push.mdx
+++ b/costgraph/integrations/focus-push.mdx
@@ -46,32 +46,94 @@ curl -X POST https://api.costgraph.ai/api/v1/tenant/billing/focus \
     "rows": [
       {
         "BillingAccountId": "acct-1",
+        "BillingCurrency": "USD",
+        "BillingPeriodStart": "2026-07-01T00:00:00Z",
+        "BillingPeriodEnd": "2026-08-01T00:00:00Z",
         "ChargePeriodStart": "2026-07-01T00:00:00Z",
         "ChargePeriodEnd": "2026-07-02T00:00:00Z",
         "ChargeCategory": "Usage",
-        "BilledCost": 12.5,
-        "EffectiveCost": 12.5,
-        "BillingCurrency": "USD",
+        "ChargeDescription": "Internal platform, shared cluster",
+        "Provider": "acme",
         "ServiceName": "Internal Platform",
-        "ProviderName": "acme",
-        "ResourceId": "svc-42"
+        "BilledCost": "12.50",
+        "EffectiveCost": "12.50",
+        "ListCost": "15.00"
       }
     ]
   }'
 ```
 
-Rows are FOCUS 1.2 records. Every row is validated, and a row that fails validation
-rejects the whole batch, so nothing lands half-applied.
+Every row is validated, and a row that fails validation rejects the whole batch, so
+nothing lands half-applied. The `422` response names the offending row index.
+
+## Request body
+
+| Field | Required | Meaning |
+|-------|----------|---------|
+| `connection_id` | **yes** | The `fpc_...` id of the push connection. |
+| `charge_period_start` | **yes** | Start of the window this batch describes, RFC 3339. |
+| `charge_period_end` | **yes** | End of the window. Must be after the start, and no more than 366 days later. |
+| `rows` | **yes** | The FOCUS records. |
+| `complete` | no | `true` replaces the window. Omitted or `false` appends. |
+| `focus_version` | no | The FOCUS version the rows conform to, for example `1.2`. Recorded against the batch. |
+
+## Row fields
+
+Costs and quantities are **strings**, not numbers, so no precision is lost in JSON.
+Timestamps are RFC 3339.
+
+### Required on every row
+
+| Field | Notes |
+|-------|-------|
+| `BillingAccountId` | Non-empty. Becomes the account the spend is attributed to. |
+| `BillingCurrency` | Uppercase ISO 4217, for example `USD`. Lowercase is rejected. |
+| `BillingPeriodStart` / `BillingPeriodEnd` | End must be after start. The invoice period the charge belongs to. |
+| `ChargePeriodStart` / `ChargePeriodEnd` | End must be after start. Start must fall inside the window the batch declares. |
+| `ChargeCategory` | One of `Usage`, `Purchase`, `Tax`, `Credit`, `Adjustment`. |
+| `ChargeDescription` | Non-empty. |
+| `Provider` | Non-empty. Every row in a batch must agree, and must match the connection. |
+| `ServiceName` | Non-empty. |
+| `BilledCost` | Decimal string. |
+| `EffectiveCost` | Decimal string. Amortised cost; this is what CostGraph reports on. |
+| `ListCost` | Decimal string. |
+
+### Constrained when present
+
+| Field | Constraint |
+|-------|-----------|
+| `ChargeClass` | Only `Correction` is accepted. |
+| `ServiceCategory` | One of `AI and Machine Learning`, `Analytics`, `Business Applications`, `Compute`, `Databases`, `Developer Tools`, `Identity`, `Integration`, `Internet of Things`, `Management and Governance`, `Media`, `Migration`, `Mobile`, `Multicloud`, `Networking`, `Security`, `Storage`, `Web`, `Other`. |
+| `ContractedCost` | Must parse as a decimal. |
+| `SubAccountName`, `SubAccountType` | Require `SubAccountId` to be set too. |
+
+### Optional
+
+Everything else in FOCUS 1.2 is accepted and stored, and omitting it is fine:
+
+`AvailabilityZone`, `BillingAccountName`, `BillingAccountType`, `CapacityReservationId`,
+`CapacityReservationStatus`, `ChargeFrequency`, `CommitmentDiscountCategory`,
+`CommitmentDiscountId`, `CommitmentDiscountName`, `CommitmentDiscountQuantity`,
+`CommitmentDiscountStatus`, `CommitmentDiscountType`, `CommitmentDiscountUnit`,
+`ConsumedQuantity`, `ConsumedUnit`, `ContractedUnitPrice`, `InvoiceId`, `InvoiceIssuer`,
+`ListUnitPrice`, `PricingCategory`, `PricingCurrency`,
+`PricingCurrencyContractedUnitPrice`, `PricingCurrencyEffectiveCost`,
+`PricingCurrencyListUnitPrice`, `PricingQuantity`, `PricingUnit`, `Publisher`,
+`RegionId`, `RegionName`, `ResourceId`, `ResourceName`, `ResourceType`,
+`ServiceSubcategory`, `SkuId`, `SkuMeter`, `SkuPriceId`, `SkuPriceDetails`,
+`SubAccountId`, `Tags`.
+
+<Note>
+Send `ResourceId` wherever you have one. Without it a charge can be totalled but not
+attributed to a thing, so it will not appear in resource-level breakdowns.
+</Note>
+
+Any key CostGraph does not recognise is kept as a provider extension rather than
+rejected, so a dialect that carries extra columns round-trips.
 
 ## The window and the `complete` flag
 
 Each push declares the charge period it covers, and what you are claiming about it.
-
-| Field | Meaning |
-|-------|---------|
-| `charge_period_start` / `charge_period_end` | The window this batch describes. End must be after start, and the window must not exceed 366 days. |
-| `complete` | `true` replaces the window. `false` (or omitted) appends to it. |
-| `focus_version` | The FOCUS version the rows conform to, for example `1.2`. |
 
 `complete: true` deletes everything previously ingested for that connection inside
 the window and replaces it with this batch. That is what makes re-sending a month

--- a/costgraph/integrations/github.mdx
+++ b/costgraph/integrations/github.mdx
@@ -16,7 +16,7 @@ repository, carrying both gross and net billed cost.
     You supply a read-only token and we call GitHub once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
+    You send us FOCUS records over the API. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
@@ -40,11 +40,8 @@ in GitHub at any time and the connection stops; nothing else is affected.
 
 ## Push it yourself
 
-1. Open **Settings -> Integrations** and pick **FOCUS push**.
-2. Create the connection and copy its **Connection ID**.
-3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider github`.
-5. Send the records to CostGraph, quoting the connection id and API key.
+Send the charges to CostGraph as FOCUS records instead. [Push FOCUS data](/costgraph/integrations/focus-push) covers the connection id,
+the `focus:write` key, and the request shape.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/grafanacloud.mdx
+++ b/costgraph/integrations/grafanacloud.mdx
@@ -18,7 +18,7 @@ organization-level row.
     You supply a read-only token and we call Grafana Cloud once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
+    You send us FOCUS records over the API. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
@@ -48,11 +48,8 @@ in Grafana Cloud at any time and the connection stops; nothing else is affected.
 
 ## Push it yourself
 
-1. Open **Settings -> Integrations** and pick **FOCUS push**.
-2. Create the connection and copy its **Connection ID**.
-3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider grafanacloud`.
-5. Send the records to CostGraph, quoting the connection id and API key.
+Send the charges to CostGraph as FOCUS records instead. [Push FOCUS data](/costgraph/integrations/focus-push) covers the connection id,
+the `focus:write` key, and the request shape.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/helicone.mdx
+++ b/costgraph/integrations/helicone.mdx
@@ -14,7 +14,7 @@ CostGraph reads Helicone as **FOCUS 1.2** records at a grain of day x model x up
     You supply read-only credentials and we call Helicone once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
+    You send us FOCUS records over the API. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
@@ -36,11 +36,8 @@ Helicone at any time and the connection stops; nothing else is affected.
 
 ## Push it yourself
 
-1. Open **Settings -> Integrations** and pick **FOCUS push**.
-2. Create the connection and copy its **Connection ID**.
-3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider helicone`.
-5. Send the records to CostGraph, quoting the connection id and API key.
+Send the charges to CostGraph as FOCUS records instead. [Push FOCUS data](/costgraph/integrations/focus-push) covers the connection id,
+the `focus:write` key, and the request shape.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/modal.mdx
+++ b/costgraph/integrations/modal.mdx
@@ -14,7 +14,7 @@ CostGraph reads Modal as **FOCUS 1.2** records at a grain of day x object (per-r
     You supply read-only credentials and we call Modal once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
+    You send us FOCUS records over the API. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
@@ -36,11 +36,8 @@ Modal at any time and the connection stops; nothing else is affected.
 
 ## Push it yourself
 
-1. Open **Settings -> Integrations** and pick **FOCUS push**.
-2. Create the connection and copy its **Connection ID**.
-3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider modal`.
-5. Send the records to CostGraph, quoting the connection id and API key.
+Send the charges to CostGraph as FOCUS records instead. [Push FOCUS data](/costgraph/integrations/focus-push) covers the connection id,
+the `focus:write` key, and the request shape.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/openai.mdx
+++ b/costgraph/integrations/openai.mdx
@@ -14,7 +14,7 @@ CostGraph reads OpenAI as **FOCUS 1.2** records at a grain of day x model x toke
     You supply read-only credentials and we call OpenAI once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
+    You send us FOCUS records over the API. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
@@ -36,11 +36,8 @@ OpenAI at any time and the connection stops; nothing else is affected.
 
 ## Push it yourself
 
-1. Open **Settings -> Integrations** and pick **FOCUS push**.
-2. Create the connection and copy its **Connection ID**.
-3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider openai`.
-5. Send the records to CostGraph, quoting the connection id and API key.
+Send the charges to CostGraph as FOCUS records instead. [Push FOCUS data](/costgraph/integrations/focus-push) covers the connection id,
+the `focus:write` key, and the request shape.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/openrouter.mdx
+++ b/costgraph/integrations/openrouter.mdx
@@ -14,7 +14,7 @@ CostGraph reads OpenRouter as **FOCUS 1.2** records at a grain of day x model x 
     You supply read-only credentials and we call OpenRouter once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
+    You send us FOCUS records over the API. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
@@ -36,11 +36,8 @@ OpenRouter at any time and the connection stops; nothing else is affected.
 
 ## Push it yourself
 
-1. Open **Settings -> Integrations** and pick **FOCUS push**.
-2. Create the connection and copy its **Connection ID**.
-3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider openrouter`.
-5. Send the records to CostGraph, quoting the connection id and API key.
+Send the charges to CostGraph as FOCUS records instead. [Push FOCUS data](/costgraph/integrations/focus-push) covers the connection id,
+the `focus:write` key, and the request shape.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/ovhcloud.mdx
+++ b/costgraph/integrations/ovhcloud.mdx
@@ -14,7 +14,7 @@ CostGraph reads OVHcloud as **FOCUS 1.2** records at a grain of bill line item.
     You supply read-only credentials and we call OVHcloud once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
+    You send us FOCUS records over the API. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
@@ -37,11 +37,8 @@ OVHcloud at any time and the connection stops; nothing else is affected.
 
 ## Push it yourself
 
-1. Open **Settings -> Integrations** and pick **FOCUS push**.
-2. Create the connection and copy its **Connection ID**.
-3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider ovhcloud`.
-5. Send the records to CostGraph, quoting the connection id and API key.
+Send the charges to CostGraph as FOCUS records instead. [Push FOCUS data](/costgraph/integrations/focus-push) covers the connection id,
+the `focus:write` key, and the request shape.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/respanai.mdx
+++ b/costgraph/integrations/respanai.mdx
@@ -16,7 +16,7 @@ CostGraph reads RespanAI as **FOCUS 1.2** records at a grain of day x model x up
     You supply read-only credentials and we call RespanAI once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
+    You send us FOCUS records over the API. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
@@ -38,11 +38,8 @@ RespanAI at any time and the connection stops; nothing else is affected.
 
 ## Push it yourself
 
-1. Open **Settings -> Integrations** and pick **FOCUS push**.
-2. Create the connection and copy its **Connection ID**.
-3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider respanai`.
-5. Send the records to CostGraph, quoting the connection id and API key.
+Send the charges to CostGraph as FOCUS records instead. [Push FOCUS data](/costgraph/integrations/focus-push) covers the connection id,
+the `focus:write` key, and the request shape.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/scaleway.mdx
+++ b/costgraph/integrations/scaleway.mdx
@@ -14,7 +14,7 @@ CostGraph reads Scaleway as **FOCUS 1.2** records at a grain of day x project x 
     You supply read-only credentials and we call Scaleway once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
+    You send us FOCUS records over the API. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
@@ -38,11 +38,8 @@ API key in Scaleway at any time and the connection stops; nothing else is affect
 
 ## Push it yourself
 
-1. Open **Settings -> Integrations** and pick **FOCUS push**.
-2. Create the connection and copy its **Connection ID**.
-3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider scaleway`.
-5. Send the records to CostGraph, quoting the connection id and API key.
+Send the charges to CostGraph as FOCUS records instead. [Push FOCUS data](/costgraph/integrations/focus-push) covers the connection id,
+the `focus:write` key, and the request shape.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/stackit.mdx
+++ b/costgraph/integrations/stackit.mdx
@@ -14,7 +14,7 @@ CostGraph reads STACKIT as **FOCUS 1.2** records at a grain of day x project x s
     You supply read-only credentials and we call STACKIT once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
+    You send us FOCUS records over the API. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
@@ -44,11 +44,8 @@ STACKIT at any time and the connection stops; nothing else is affected.
 
 ## Push it yourself
 
-1. Open **Settings -> Integrations** and pick **FOCUS push**.
-2. Create the connection and copy its **Connection ID**.
-3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider stackit`.
-5. Send the records to CostGraph, quoting the connection id and API key.
+Send the charges to CostGraph as FOCUS records instead. [Push FOCUS data](/costgraph/integrations/focus-push) covers the connection id,
+the `focus:write` key, and the request shape.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/vercel.mdx
+++ b/costgraph/integrations/vercel.mdx
@@ -14,7 +14,7 @@ CostGraph reads Vercel as **FOCUS 1.2** records at a grain of day x service x pr
     You supply read-only credentials and we call Vercel once a day. Nothing to run.
   </Card>
   <Card title="You push it" icon="cloud-arrow-up">
-    You run the CostGraph exporter yourself. Credentials never leave your infrastructure.
+    You send us FOCUS records over the API. Credentials never leave your infrastructure.
   </Card>
 </CardGroup>
 
@@ -37,11 +37,8 @@ Vercel at any time and the connection stops; nothing else is affected.
 
 ## Push it yourself
 
-1. Open **Settings -> Integrations** and pick **FOCUS push**.
-2. Create the connection and copy its **Connection ID**.
-3. Create a CostGraph API key with the `focus:write` scope.
-4. Run the exporter with `--provider vercel`.
-5. Send the records to CostGraph, quoting the connection id and API key.
+Send the charges to CostGraph as FOCUS records instead. [Push FOCUS data](/costgraph/integrations/focus-push) covers the connection id,
+the `focus:write` key, and the request shape.
 
 ## What CostGraph does with it
 

--- a/docs.json
+++ b/docs.json
@@ -64,6 +64,7 @@
             "group": "Integrations",
             "icon": "plug",
             "pages": [
+              "costgraph/integrations/focus-push",
               "costgraph/integrations/anthropic",
               "costgraph/integrations/aws",
               "costgraph/integrations/cloudflare",


### PR DESCRIPTION
There was no page for `POST /api/v1/tenant/billing/focus` at all, and the push half of every provider page told customers to run the exporter themselves, which is no longer how billing data reaches us.

## New page

`costgraph/integrations/focus-push` documents the API process end to end: creating the push connection, the `focus:write` key, the request, the replace-vs-append semantics of `complete`, the 32 MB limit, a daily loop that stays idempotent, and every response code the endpoint returns.

The row spec is complete and marks required against optional, taken from `focus.Validate` and the generated record rather than from the FOCUS site:

- **Required on every row** (13): `BillingAccountId`, `BillingCurrency`, `BillingPeriodStart`/`End`, `ChargePeriodStart`/`End`, `ChargeCategory`, `ChargeDescription`, `Provider`, `ServiceName`, `BilledCost`, `EffectiveCost`, `ListCost`.
- **Constrained when present**: `ChargeClass` (only `Correction`), `ServiceCategory` (19 values), `ContractedCost` (must parse), `SubAccountName`/`Type` (need `SubAccountId`).
- **Optional**: the remaining 39 fields, listed in full.

Worth calling out two things the spec alone would not tell you: costs are strings so JSON keeps precision, and `ChargeDescription` is a pointer on the record but validation rejects an empty one, so it is genuinely required.

## Provider pages

All 17 said "You run the CostGraph exporter yourself" and gave exporter CLI steps. The card now says you send FOCUS records over the API, and the procedure is replaced by a link to the new page rather than being duplicated per provider.