### PR TITLE
Link the pricing API reference from the Pricing IDs page

### DIFF
--- a/costgraph/operator/on-prem-pricing.mdx
+++ b/costgraph/operator/on-prem-pricing.mdx
@@ -21,8 +21,8 @@ costgraph.ai/pricing-id.storage = <uuid>
 |--------|-------------------|---------------|
 | `.compute` | compute rate | [`POST /marketplace/providers/compute`](https://docs.costgraph.ai/api-reference/register-a-custom-provider) |
 | `.storage` | disk rate | [`POST /marketplace/providers/disks`](https://docs.costgraph.ai/api-reference/register-a-custom-disk-provider) |
-| `.database` | managed database rate | `POST /marketplace/providers/databases` |
-| `.model` | model token rate | `POST /marketplace/providers/models` |
+| `.database` | managed database rate | [`POST /marketplace/providers/databases`](https://docs.costgraph.ai/api-reference/register-custom-database-pricing) |
+| `.model` | model token rate | [`POST /marketplace/providers/models`](https://docs.costgraph.ai/api-reference/register-custom-model-pricing) |
 
 A key with no suffix is read as `.compute` on a node and `.storage` on a volume.
 Prefer the explicit suffix.

--- a/costgraph/operator/on-prem-pricing.mdx
+++ b/costgraph/operator/on-prem-pricing.mdx
@@ -19,8 +19,8 @@ costgraph.ai/pricing-id.storage = <uuid>
 
 | Suffix | Rate it points at | Register with |
 |--------|-------------------|---------------|
-| `.compute` | compute rate | `POST /marketplace/providers/compute` |
-| `.storage` | disk rate | `POST /marketplace/providers/disks` |
+| `.compute` | compute rate | [`POST /marketplace/providers/compute`](https://docs.costgraph.ai/api-reference/register-a-custom-provider) |
+| `.storage` | disk rate | [`POST /marketplace/providers/disks`](https://docs.costgraph.ai/api-reference/register-a-custom-disk-provider) |
 | `.database` | managed database rate | `POST /marketplace/providers/databases` |
 | `.model` | model token rate | `POST /marketplace/providers/models` |
 
@@ -28,6 +28,12 @@ A key with no suffix is read as `.compute` on a node and `.storage` on a volume.
 Prefer the explicit suffix.
 
 ## Register a rate
+
+Full request and response schema:
+[Register a custom provider](https://docs.costgraph.ai/api-reference/register-a-custom-provider)
+for compute, and
+[Register a custom disk provider](https://docs.costgraph.ai/api-reference/register-a-custom-disk-provider)
+for storage.
 
 ```bash
 curl -X POST https://pricing.baselinehq.cloud/marketplace/providers/compute \


### PR DESCRIPTION
Follow-up to #61, which merged before these two commits were pushed.

Links each dimension in the table to the endpoint that registers that kind of rate, and points the "Register a rate" section at the compute and disk reference pages for the full schema.

The `.database` and `.model` links resolve only once pricingapi #131 lands and `api-reference/openapi.json` plus the Marketplace group in `docs.json` are regenerated from the new spec - the checked-in spec currently carries only the compute and disk marketplace operations. Slugs come from the swagger summaries on that branch: `Register custom database pricing` and `Register custom model pricing`.