### PR TITLE
Document the CloudShell setup path for AWS and GCP

### DIFF
--- a/costgraph/integrations/aws.mdx
+++ b/costgraph/integrations/aws.mdx
@@ -4,8 +4,8 @@ description: "Connect an AWS account to CostGraph for FOCUS-based cost, allocati
 ---
 
 CostGraph reads your AWS spend from a **FOCUS Data Export** delivered to S3. Unlike
-Google Cloud, AWS exposes a full API for this, so the entire setup can be automated -
-CostGraph (or a short Terraform module) creates the export and the read role for you.
+Google Cloud, AWS exposes a full API for this, so the entire setup is automated - one
+CloudShell command (or a short Terraform module) creates the export and the read role.
 
 ## What you enable
 
@@ -13,10 +13,41 @@ A single **FOCUS 1.2 Data Export** (`FOCUS_1_2_AWS`) written as Parquet to an S3
 bucket. It carries billed and effective cost, usage, credits, and commitment
 (Savings Plans / Reserved Instances) columns in the normalized FOCUS schema.
 
-## Automated setup (recommended)
+## Setup in CloudShell (recommended)
 
-CostGraph creates the export on your behalf when you connect with a role that allows
-`bcm-data-exports` and S3 bucket management, or you can apply the Terraform below. The
+The connect dialog shows a one-line command. Open **AWS CloudShell** in the management
+(payer) account and run it:
+
+```sh
+curl -sSL https://setup.costgraph.ai/integrations/aws.sh \
+  | COSTGRAPH_EXTERNAL_ID="org_..." sh
+```
+
+CloudShell already carries your console credentials, so nothing is stored or pasted
+anywhere else. The script creates the read role (trusting CostGraph's identity, locked
+to your external ID), the export bucket with public access blocked and encryption on,
+and the FOCUS 1.2 Data Export. It is idempotent - rerun it safely.
+
+It prints four values. Paste them into the connect form:
+
+```
+ROLE_ARN=arn:aws:iam::123456789012:role/CostGraph-Reader
+BUCKET=costgraph-focus-123456789012
+REGION=us-east-1
+PREFIX=focus-1-2
+```
+
+<Note>
+The external ID is issued by CostGraph and ties the role to your organization. It stops
+anyone else who learns your role ARN from assuming it. Never edit it out of the command.
+</Note>
+
+Set `COSTGRAPH_BUCKET` to use an existing bucket, or `COSTGRAPH_EXPORT_REGION` if you
+are in a different partition (GovCloud, China).
+
+## Setup with Terraform
+
+Prefer infrastructure as code? Apply the equivalent below instead of the script. The
 export is created in **us-east-1** (where AWS billing data lives), so
 `aws_bcmdataexports_export` must be managed by an AWS provider configured for that
 region. If your root provider targets another region, add an aliased one and point the
@@ -87,9 +118,11 @@ and external ID.
 ## Connect in CostGraph
 
 1. Open **Integrations** and choose **Amazon Web Services**.
-2. Provide the read role (and, for automated setup, the provisioning role), then connect.
-3. CostGraph creates or discovers the FOCUS export, validates access, and starts the
-   first sync.
+2. Run the CloudShell command shown there (or apply the Terraform above).
+3. Paste the `ROLE_ARN`, `BUCKET`, `REGION`, and `PREFIX` the script printed, then
+   connect.
+4. CostGraph assumes the role, validates it can read the export, and starts the first
+   sync.
 
 ## What CostGraph does with it
 

--- a/costgraph/integrations/gcp.mdx
+++ b/costgraph/integrations/gcp.mdx
@@ -47,8 +47,36 @@ First new rows appear within a few hours either way.
 
 ## Step 2: Grant CostGraph read access
 
-Create a service account for the billing reads (or reuse one), and note the project
-that holds the export datasets. Grant it, least-privilege:
+The connect dialog shows a one-line command. Open **Cloud Shell** in the project holding
+the export datasets and run it:
+
+```sh
+curl -sSL https://setup.costgraph.ai/integrations/gcp.sh \
+  | COSTGRAPH_EXTERNAL_ID="org_..." COSTGRAPH_BILLING_ACCOUNT_ID="0X0X0X-0X0X0X-0X0X0X" sh
+```
+
+Cloud Shell already carries your console credentials, so no key is created or pasted
+anywhere. The script creates the reader service account, finds the FOCUS and detailed
+datasets for your billing account, applies the grants below, and authorizes CostGraph's
+federated principal to impersonate it. It is idempotent - rerun it safely. If the FOCUS
+export does not exist yet it stops and points you back at Step 1.
+
+It prints the values to paste into the connect form:
+
+```
+SERVICE_ACCOUNT=costgraph-billing-reader@my-project.iam.gserviceaccount.com
+PROJECT_ID=my-project
+BILLING_ACCOUNT_ID=0X0X0X-0X0X0X-0X0X0X
+FOCUS_DATASET=gcp_billing_immutable_0X0X0X_0X0X0X_0X0X0X_us
+DETAILED_DATASET=gcp_billing_export_resource_v1_0X0X0X_0X0X0X_0X0X0X
+```
+
+Set `COSTGRAPH_PROJECT_ID` when the export lives outside your active Cloud Shell
+project, or `COSTGRAPH_SA_NAME` to reuse an existing service account.
+
+### What it grants
+
+Doing it by hand instead? These are the exact, least-privilege grants:
 
 | Role | Scope | Why |
 |------|-------|-----|
@@ -76,9 +104,9 @@ service-account key) is the correct trust model.
 ## Step 3: Connect in CostGraph
 
 1. Open **Integrations** and choose **Google Cloud**.
-2. Choose **impersonation** (recommended - authorize CostGraph's identity on your
-   service account) or paste a **service-account key**, then enter the **billing
-   account ID**.
+2. Paste the values the Cloud Shell script printed. To set it up by hand instead, choose
+   **impersonation** (recommended - authorize CostGraph's identity on your service
+   account) or paste a **service-account key**, then enter the **billing account ID**.
 3. CostGraph validates it can run a query and read the FOCUS dataset, then starts the
    first sync. If a role is missing, the connect screen names the exact grant to add.
 
@@ -93,7 +121,8 @@ service-account key) is the correct trust model.
 
 ## Automating the setup
 
-Everything except the export toggle can be provisioned as code:
+The Cloud Shell script in Step 2 covers this for a single billing account. Across many
+projects, provision it as code instead:
 
 - `google_bigquery_dataset` for the Detailed destination
 - `google_bigquery_dataset_iam_member` / `google_project_iam_member` for the grants


### PR DESCRIPTION
Documents the setup scripts published to `setup.costgraph.ai/integrations/` (baselinehq/focus-exporter#52).

- **AWS**: leads with the CloudShell command, the four values it prints, and a note on why the external id must not be edited out. Terraform stays as the alternative rather than the primary path.
- **GCP**: Cloud Shell becomes step 2, with the grant table kept for anyone provisioning by hand. The FOCUS export toggle stays a manual Console step because Google exposes no API for it.

Merge after the scripts are actually being served, otherwise the documented URLs 404.

Follow-up worth doing: `agent.mdx` presents its `setup.costgraph.ai` script with `<Tabs>` and a download-then-inspect variant. These two pages should match that shape.