### PR TITLE
Add Redis Cloud integration page

### DIFF
--- a/costgraph/integrations/rediscloud.mdx
+++ b/costgraph/integrations/rediscloud.mdx
@@ -1,0 +1,53 @@
+---
+title: Redis Cloud
+description: "Bring Redis Cloud cost into CostGraph, pulled by us or pushed by you"
+---
+
+Redis Cloud emits a FOCUS-native cost report per subscription and database, so
+spend is attributed per resource across each usage period.
+
+CostGraph reads Redis Cloud as **FOCUS 1.2** records at a grain of cost-report
+line item (subscription x database x usage period).
+
+## Choose how the data reaches us
+
+<CardGroup cols={2}>
+  <Card title="CostGraph pulls it" icon="cloud-arrow-down">
+    You supply read-only credentials and we call Redis Cloud once a day. Nothing to run.
+  </Card>
+  <Card title="You push it" icon="cloud-arrow-up">
+    You send us FOCUS records over the API. Credentials never leave your infrastructure.
+  </Card>
+</CardGroup>
+
+## Let CostGraph pull
+
+1. Open **Settings -> Integrations** and pick **Redis Cloud**.
+2. Name the connection and pick the tenant these charges belong to.
+3. Fill in the values the form asks for. It lists exactly the keys Redis Cloud
+   needs and explains the permission each one requires. You supply two keys:
+   the account-level API key (enabled under **Account Settings -> API**) and the
+   user-level secret key (**Account Settings -> API keys**). The account needs
+   the Owner, Billing admin, or Viewer role.
+4. Select **Connect**.
+
+CostGraph verifies the credentials with a short fetch before saving, so a wrong
+value or a missing permission fails while you are still on the form.
+
+<Note>
+The FOCUS cost report is in limited availability on Redis Cloud; request access
+from Redis support if the report is not yet enabled on your account. Credentials
+are encrypted at rest and used only to read billing data. Revoke either key in
+Redis Cloud at any time and the connection stops; nothing else is affected.
+</Note>
+
+## Push it yourself
+
+Send the cost report to CostGraph as FOCUS records instead. [Push FOCUS data](/costgraph/integrations/focus-push) covers the connection id,
+the `focus:write` key, and the request shape.
+
+## What CostGraph does with it
+
+Records land as raw billing rows, are normalised into line items, and roll up into
+daily cost. From there Redis Cloud spend appears in Cost Overview and in anomaly
+detection alongside every other provider.

--- a/docs.json
+++ b/docs.json
@@ -81,6 +81,7 @@
               "costgraph/integrations/openrouter",
               "costgraph/integrations/ovhcloud",
               "costgraph/integrations/planetscale",
+              "costgraph/integrations/rediscloud",
               "costgraph/integrations/respanai",
               "costgraph/integrations/scaleway",
               "costgraph/integrations/stackit",
@@ -290,6 +291,10 @@
     {
       "source": "/costgraph/focus-exporter/planetscale",
       "destination": "/costgraph/integrations/planetscale"
+    },
+    {
+      "source": "/costgraph/focus-exporter/rediscloud",
+      "destination": "/costgraph/integrations/rediscloud"
     },
     {
       "source": "/costgraph/focus-exporter/respanai",


### PR DESCRIPTION
Customer-facing onboarding page for the Redis Cloud integration (managed database, FOCUS-native cost report). Mirrors the Scaleway/PlanetScale pages: pull vs push, the two API keys and the roles they need, and the limited-availability note for the FOCUS cost report. Adds the nav entry and the focus-exporter redirect.