### PR TITLE
Add Datadog integration page

### DIFF
--- a/costgraph/integrations/datadog.mdx
+++ b/costgraph/integrations/datadog.mdx
@@ -1,0 +1,55 @@
+---
+title: Datadog
+description: "Bring your Datadog subscription spend into CostGraph, pulled by us or pushed by you"
+---
+
+Datadog reports your own Datadog bill broken down by organization and product,
+so spend is attributed per product and, in a multi-org account, per sub-org.
+
+CostGraph reads Datadog as **FOCUS 1.2** records at a grain of month x
+organization x product x charge type.
+
+## Choose how the data reaches us
+
+<CardGroup cols={2}>
+  <Card title="CostGraph pulls it" icon="cloud-arrow-down">
+    You supply read-only credentials and we call Datadog once a day. Nothing to run.
+  </Card>
+  <Card title="You push it" icon="cloud-arrow-up">
+    You send us FOCUS records over the API. Credentials never leave your infrastructure.
+  </Card>
+</CardGroup>
+
+## Let CostGraph pull
+
+1. Open **Settings -> Integrations** and pick **Datadog**.
+2. Name the connection and pick the tenant these charges belong to.
+3. Fill in the values the form asks for. It lists exactly the keys Datadog needs
+   and explains the permission each one requires. You supply an **API key** and
+   an **application key** scoped to `usage_read` and `billing_read`, both created
+   by a parent-org admin (the cost endpoints are parent-org only). If your
+   account is not on US1, set the Datadog **site**.
+4. Select **Connect**.
+
+CostGraph verifies the credentials with a short fetch before saving, so a wrong
+value or a missing permission fails while you are still on the form.
+
+<Note>
+Use a long-lived API key rather than a personal access token for an unattended
+connection: a personal token is user-bound and expires. Credentials are
+encrypted at rest and used only to read billing data. Revoke either key in
+Datadog at any time and the connection stops; nothing else is affected.
+</Note>
+
+## Push it yourself
+
+Send the cost report to CostGraph as FOCUS records instead. [Push FOCUS data](/costgraph/integrations/focus-push) covers the connection id,
+the `focus:write` key, and the request shape.
+
+## What CostGraph does with it
+
+Records land as raw billing rows, are normalised into line items, and roll up into
+daily cost. From there Datadog spend appears in Cost Overview and in anomaly
+detection alongside every other provider. In a multi-org account the paying
+organization is the billing account and each sub-org is a sub-account, so spend
+is attributed per tenant.

--- a/docs.json
+++ b/docs.json
@@ -71,6 +71,7 @@
               "costgraph/integrations/confluent",
               "costgraph/integrations/costgraph",
               "costgraph/integrations/cursor",
+              "costgraph/integrations/datadog",
               "costgraph/integrations/digitalocean",
               "costgraph/integrations/gcp",
               "costgraph/integrations/github",
@@ -255,6 +256,10 @@
     {
       "source": "/costgraph/focus-exporter/cursor",
       "destination": "/costgraph/integrations/cursor"
+    },
+    {
+      "source": "/costgraph/focus-exporter/datadog",
+      "destination": "/costgraph/integrations/datadog"
     },
     {
       "source": "/costgraph/focus-exporter/digitalocean",


### PR DESCRIPTION
Customer-facing onboarding page for the Datadog integration (observability, own subscription spend, FOCUS 1.2 at month x org x product x charge type). Mirrors the Redis Cloud/Scaleway pages: pull vs push, the API key + application key and the usage_read/billing_read scopes, the long-lived-key note, and multi-org tenancy. Adds the nav entry and the focus-exporter redirect.