### PR TITLE
Diagram how a pricing ID reaches a resource

### DIFF
--- a/costgraph/operator/on-prem-pricing.mdx
+++ b/costgraph/operator/on-prem-pricing.mdx
@@ -15,6 +15,18 @@ costgraph.ai/pricing-id.compute = <uuid>
 costgraph.ai/pricing-id.storage = <uuid>
 ```
 
+Register a rate once, then tag every resource that bills at it:
+
+```mermaid
+flowchart LR
+  R["Rate you registered<br/>in the marketplace"] -->|returns an ID| ID(["pricing ID"])
+  ID -.->|pricing-id.compute| N["Node"]
+  ID -.->|pricing-id.storage| V["Volume"]
+```
+
+The same ID can be tagged onto as many resources as bill at that rate, and
+changing the rate reprices all of them at once.
+
 ## Dimensions
 
 | Suffix | Rate it points at | Register with |
@@ -96,10 +108,21 @@ Azure tag names reject `/`. GCP label keys allow only lowercase letters, digits,
 
 ## Inheritance
 
-A pin applies to the object that carries it and to everything under it that has
-no nearer pin of the same dimension. Tag a node and its pods inherit the compute
-rate; tag one namespace differently and only that namespace changes. The nearest
-pin wins.
+A pin applies to the object that carries it and to the objects that object owns.
+Tag a workload and its pods inherit the rate. An object carrying its own pin of
+the same dimension keeps its own: the nearest pin wins.
+
+```mermaid
+flowchart TD
+  D["Workload<br/>pricing-id.compute = A"] --> P1["Pod<br/>inherits A"]
+  D --> P2["Pod<br/>pricing-id.compute = B<br/>keeps B"]
+```
+
+<Note>
+  Nodes and volumes are priced by the pin they carry themselves. Tagging a
+  namespace does not price the nodes or volumes used inside it - tag those
+  directly.
+</Note>
 
 ## What a pin changes
 

--- a/costgraph/operator/on-prem-pricing.mdx
+++ b/costgraph/operator/on-prem-pricing.mdx
@@ -109,30 +109,17 @@ Azure tag names reject `/`. GCP label keys allow only lowercase letters, digits,
 ## Inheritance
 
 Every object is priced in its own right. An object with no pin of its own takes
-the rate from the nearest scope above it, so tagging one node can price what sits
-on it without tagging each thing individually.
+the rate from the nearest scope above it, so tagging one node can price the
+volumes on it without tagging each one.
 
 ```mermaid
 flowchart TD
-  N["Node<br/>pricing-id.compute = A<br/>pricing-id.storage = A"]
-  N -.->|default for| POD["Pod<br/>inherits A"]
-  N -.->|default for| PV["Volume<br/>inherits A"]
+  N["Node<br/>pricing-id.storage = A"]
+  N -.->|default for| PV["Volume on that node<br/>inherits A"]
   PV2["Volume<br/>pricing-id.storage = B<br/>keeps its own rate"]
 ```
 
-The nearest pin wins. Searching outward from the object, the first one found
-decides the rate:
-
-```mermaid
-flowchart TD
-  A["1. The object's own pin"] --> B["2. The workload that owns it"]
-  B --> C["3. Its namespace"]
-  C --> D["4. The node it runs on"]
-  D --> E["5. No pin: attribute matching"]
-```
-
-A volume and its claim are separate objects and can carry different rates, the
-same way a node and the pods on it can. Each looks outward along its own path:
+The nearest pin wins, and each kind of object looks outward along its own path:
 
 ```mermaid
 flowchart LR
@@ -144,10 +131,20 @@ flowchart LR
     direction TB
     c1["own pin"] --> c2["its volume"] --> c3["its namespace"] --> c4["the node"]
   end
+  subgraph NODE["Node"]
+    direction TB
+    n1["own pin"] --> n2["attribute matching"]
+  end
 ```
 
-A volume with no consumer has no node above it, so with no pin of its own it
-falls straight to attribute matching.
+A volume and its claim are separate objects and can carry different rates. A
+volume with no consumer has no node above it, so with no pin of its own it falls
+straight to attribute matching.
+
+<Note>
+  A node is not in any namespace, so tagging a namespace never changes a node's
+  own rate. It reaches the claims in that namespace.
+</Note>
 
 ## What a pin changes
 

--- a/costgraph/operator/on-prem-pricing.mdx
+++ b/costgraph/operator/on-prem-pricing.mdx
@@ -84,27 +84,26 @@ Review what is tagged with:
 kubectl get nodes -L costgraph.ai/pricing-id.compute
 ```
 
-Everywhere else, use the provider's resource tags with the same key and value.
+Pins are read from Kubernetes objects: nodes, volumes and volume claims.
 
 A tagged resource needs no other metadata. CPU and memory still come from the
 node's capacity, and volume size from the PV, because those are the billed
 quantities.
 
-## Tag keys on each provider
+## Key spellings
 
-Not every provider accepts the canonical key verbatim. CostGraph matches keys
-case-insensitively after replacing `/`, `.` and `-` with `_`, so the alias your
-provider allows resolves to the same pin.
+Some platforms reject the canonical key, and a label set on a cloud instance can
+reach the node in a rewritten form. CostGraph matches keys case-insensitively
+after replacing `/`, `.` and `-` with `_`, so every spelling below resolves to
+the same pin.
 
-| Target | Key to set |
-|--------|------------|
-| Kubernetes labels | `costgraph.ai/pricing-id.compute` |
-| AWS tags | `costgraph.ai/pricing-id.compute` |
-| Azure tags | `costgraph.ai_pricing-id.compute` |
-| GCP labels | `costgraph_ai_pricing_id_compute` |
+| Spelling | Where it comes from |
+|----------|---------------------|
+| `costgraph.ai/pricing-id.compute` | the canonical key |
+| `costgraph.ai_pricing-id.compute` | Azure, whose tag names reject `/` |
+| `costgraph_ai_pricing_id_compute` | GCP, whose label keys allow only lowercase letters, digits, `-` and `_` |
 
-Azure tag names reject `/`. GCP label keys allow only lowercase letters, digits,
-`-` and `_`, and must start with a letter.
+Set whichever your tooling accepts.
 
 ## Inheritance
 
@@ -148,11 +147,13 @@ straight to attribute matching.
 
 ## What a pin changes
 
-A pin sets **ListCost**: the rate you would be charged at list. It never
-overwrites **BilledCost**, which comes from an ingested bill. On a resource with
-no bill behind it, such as a bare-metal node, ListCost is the only cost there is.
-On a resource that is also billed, you get both, and the difference is your
-discount. Pins never double-count against an invoice.
+A pin decides the rate CostGraph uses to cost that resource, replacing attribute
+matching for that dimension. Nothing else about the resource changes: CPU and
+memory still come from the node's capacity and size from the volume, because
+those are the billed quantities.
+
+A pin is how a resource gets a cost at all when CostGraph has nothing to match
+on, such as a bare-metal node with no cloud provider behind it.
 
 ## Change a rate
 

--- a/costgraph/operator/on-prem-pricing.mdx
+++ b/costgraph/operator/on-prem-pricing.mdx
@@ -132,8 +132,22 @@ flowchart TD
 ```
 
 A volume and its claim are separate objects and can carry different rates, the
-same way a node and the pods on it can. A volume with no consumer has no node
-above it, so with no pin of its own it falls straight to attribute matching.
+same way a node and the pods on it can. Each looks outward along its own path:
+
+```mermaid
+flowchart LR
+  subgraph V["Volume"]
+    direction TB
+    v1["own pin"] --> v2["the node it is attached to"] --> v3["attribute matching"]
+  end
+  subgraph C["Volume claim"]
+    direction TB
+    c1["own pin"] --> c2["its volume"] --> c3["its namespace"] --> c4["the node"]
+  end
+```
+
+A volume with no consumer has no node above it, so with no pin of its own it
+falls straight to attribute matching.
 
 ## What a pin changes
 

--- a/costgraph/operator/on-prem-pricing.mdx
+++ b/costgraph/operator/on-prem-pricing.mdx
@@ -108,21 +108,32 @@ Azure tag names reject `/`. GCP label keys allow only lowercase letters, digits,
 
 ## Inheritance
 
-A pin applies to the object that carries it and to the objects that object owns.
-Tag a workload and its pods inherit the rate. An object carrying its own pin of
-the same dimension keeps its own: the nearest pin wins.
+Every object is priced in its own right. An object with no pin of its own takes
+the rate from the nearest scope above it, so tagging one node can price what sits
+on it without tagging each thing individually.
 
 ```mermaid
 flowchart TD
-  D["Workload<br/>pricing-id.compute = A"] --> P1["Pod<br/>inherits A"]
-  D --> P2["Pod<br/>pricing-id.compute = B<br/>keeps B"]
+  N["Node<br/>pricing-id.compute = A<br/>pricing-id.storage = A"]
+  N -.->|default for| POD["Pod<br/>inherits A"]
+  N -.->|default for| PV["Volume<br/>inherits A"]
+  PV2["Volume<br/>pricing-id.storage = B<br/>keeps its own rate"]
 ```
 
-<Note>
-  Nodes and volumes are priced by the pin they carry themselves. Tagging a
-  namespace does not price the nodes or volumes used inside it - tag those
-  directly.
-</Note>
+The nearest pin wins. Searching outward from the object, the first one found
+decides the rate:
+
+```mermaid
+flowchart TD
+  A["1. The object's own pin"] --> B["2. The workload that owns it"]
+  B --> C["3. Its namespace"]
+  C --> D["4. The node it runs on"]
+  D --> E["5. No pin: attribute matching"]
+```
+
+A volume and its claim are separate objects and can carry different rates, the
+same way a node and the pods on it can. A volume with no consumer has no node
+above it, so with no pin of its own it falls straight to attribute matching.
 
 ## What a pin changes
 


### PR DESCRIPTION
First use of mermaid in these docs, so this doubles as the experiment - two small diagrams on the Pricing IDs page, no internals.

1. **Registering and tagging** - a rate returns an ID, and that one ID is tagged onto every resource that bills at it.
2. **Inheritance** - a workload pin flows to its pods, and a pod with its own pin of the same dimension keeps it.

Both were rendered through mermaid-cli before committing, so they parse and are legible rather than just syntactically plausible.

## Also corrects the inheritance section

It read: *"Tag a node and its pods inherit the compute rate; tag one namespace differently and only that namespace changes."*

Neither is true. Inheritance follows ownership (a workload to its pods). A node does not own its pods, and a namespace is not on that path at all, so tagging a namespace prices nothing that runs in it. Nodes and volumes are priced by the pin they carry themselves. The page now says that, with a Note so nobody tries the namespace route.

Namespace-scoped pinning is a real gap rather than a docs error - tracked on baselinehq/backend#469, which has been corrected the same way.